### PR TITLE
- Commit 6: Ensure there is no duplicated username

### DIFF
--- a/iOS/FuFight/FuFight/Authentication/AccountNetworkManager.swift
+++ b/iOS/FuFight/FuFight/Authentication/AccountNetworkManager.swift
@@ -158,6 +158,17 @@ extension AccountNetworkManager {
         }
     }
 
+    static func isUnique(username: String) async throws -> Bool {
+        do {
+            let snapshot = try await accountDb.whereField(kUSERNAME, isEqualTo: username).limit(to: 1).getDocuments()
+            let hasDuplicate = !snapshot.documents.isEmpty
+            LOGD("DB: Username \(username) has duplicates = \(hasDuplicate)", from: self)
+            return hasDuplicate
+        } catch {
+            throw error
+        }
+    }
+
     ///Get uiImage from url
 //    static func downloadImage(from url: URL) async throws -> UIImage? {
 //        let (data, response) = try await URLSession.shared.data(from: url)

--- a/iOS/FuFight/FuFight/Authentication/AuthenticationViewModel.swift
+++ b/iOS/FuFight/FuFight/Authentication/AuthenticationViewModel.swift
@@ -179,14 +179,20 @@ private extension AuthenticationViewModel {
         guard !topFieldHasError else {
             return handleError(MainError(type: .invalidUsername))
         }
+        let username = topFieldText
         Task {
             do {
+                ///Ensure non duplicated username
+                loadingMessage = Str.checkingUsername
+                guard try await !AccountNetworkManager.isUnique(username: username) else {
+                    return handleError(MainError(type: .notUniqueUsername))
+                }
                 ///Store user's photo to Storage
                 loadingMessage = Str.storingPhoto
                 if let imageUrl = try await AccountNetworkManager.storePhoto(selectedImage, for: account.userId) {
                     loadingMessage = Str.updatingUser
-                    try await AccountNetworkManager.updateAuthenticatedAccount(username: topFieldText, photoURL: imageUrl)
-                    account.username = topFieldText
+                    try await AccountNetworkManager.updateAuthenticatedAccount(username: username, photoURL: imageUrl)
+                    account.username = username
                     account.imageUrl = imageUrl
                     transitionToHomeView()
                     loadingMessage = Str.savingUser

--- a/iOS/FuFight/FuFight/Helpers/ConstantTexts.swift
+++ b/iOS/FuFight/FuFight/Helpers/ConstantTexts.swift
@@ -42,4 +42,5 @@ struct Str {
     static let deletingData = "Deleting user's data"
     static let deletingUser = "Deleting user"
     static let loggingOut = "Logging out"
+    static let checkingUsername = "Checking username"
 }

--- a/iOS/FuFight/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
+++ b/iOS/FuFight/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
@@ -21,6 +21,7 @@ enum MainErrorType {
     case invalidEmail
     case invalidPassword
     case invalidUsername
+    case notUniqueUsername
 
     var title: String {
         switch self {
@@ -50,6 +51,8 @@ enum MainErrorType {
             "Invalid password"
         case .invalidUsername:
             "Invalid username"
+        case .notUniqueUsername:
+            "Username is already taken"
         }
     }
 }


### PR DESCRIPTION
    - Created a function that fetches all documents in Accounts with a matching username
    - Check if username already exist in Signup’s onboard and to not complete user creation until their username is unique
    - Showed loading and handled error messages