### PR TITLE
- Commit 7: Log in with username

### DIFF
--- a/iOS/FuFight/FuFight/Authentication/AccountNetworkManager.swift
+++ b/iOS/FuFight/FuFight/Authentication/AccountNetworkManager.swift
@@ -169,6 +169,22 @@ extension AccountNetworkManager {
         }
     }
 
+    static func fetchEmailFrom(username: String) async throws -> String? {
+        do {
+            let snapshot = try await accountDb.whereField(kUSERNAME, isEqualTo: username).limit(to: 1).getDocuments()
+            for doc in snapshot.documents {
+                if doc.exists,
+                   let email = doc.data()[kEMAIL] as? String {
+                    LOGD("DB: Finished fetching email \(email) from username \(username)", from: self)
+                    return email
+                }
+            }
+            return nil
+        } catch {
+            throw error
+        }
+    }
+
     ///Get uiImage from url
 //    static func downloadImage(from url: URL) async throws -> UIImage? {
 //        let (data, response) = try await URLSession.shared.data(from: url)

--- a/iOS/FuFight/FuFight/Helpers/ConstantTexts.swift
+++ b/iOS/FuFight/FuFight/Helpers/ConstantTexts.swift
@@ -43,4 +43,5 @@ struct Str {
     static let deletingUser = "Deleting user"
     static let loggingOut = "Logging out"
     static let checkingUsername = "Checking username"
+    static let fetchingEmail = "Fetching email"
 }


### PR DESCRIPTION
    - Added a way to switch topField’s type depending on text. Since username cannot have @ character, we can assume that if field has a @, then it is an email
    - With the right topFieldType, fixed error handling and topField validations
    - Fetch email from username
    - Use that email to authenticate the user