### PR TITLE
- Commit 3: Update user’s photo and username

### DIFF
--- a/iOS/FuFight/FuFight/Account/Account.swift
+++ b/iOS/FuFight/FuFight/Account/Account.swift
@@ -16,7 +16,7 @@ class Account: ObservableObject, Codable {
     @DocumentID var id: String?
     @Published var username: String?
     @Published var photoUrl: URL?
-    @Published private(set) var email: String?
+    @Published var email: String?
     @Published private(set) var phoneNumber: String?
     @Published private(set) var createdAt: Date?
     @Published var status: Account.Status = .unfinished

--- a/iOS/FuFight/FuFight/Account/AccountView.swift
+++ b/iOS/FuFight/FuFight/Account/AccountView.swift
@@ -34,7 +34,7 @@ struct AccountView: View {
             .padding()
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    saveButton
+                    editSaveButton
                 }
             }
         }
@@ -52,9 +52,9 @@ struct AccountView: View {
         .allowsHitTesting(vm.loadingMessage == nil)
     }
 
-    var saveButton: some View {
-        Button(action: vm.saveButtonTapped) {
-            Text(Str.saveTitle)
+    var editSaveButton: some View {
+        Button(action: vm.editSaveButtonTapped) {
+            Text(vm.isViewingMode ? Str.editTitle : Str.saveTitle)
         }
         .appButton(.tertiary)
     }
@@ -69,7 +69,8 @@ struct AccountView: View {
             type: .constant(.username),
             text: $vm.usernameFieldText,
             hasError: $vm.usernameFieldHasError,
-            isActive: $vm.usernameFieldIsActive) {
+            isActive: $vm.usernameFieldIsActive, 
+            isDisabled: $vm.isViewingMode) {
                 TODO("TODO: CHECK USERNAME HERE")
             }
             .onSubmit {
@@ -82,14 +83,15 @@ struct AccountView: View {
             type: .constant(.email),
             text: $vm.emailFieldText,
             hasError: $vm.emailFieldHasError,
-            isActive: $vm.emailFieldIsActive)
+            isActive: $vm.emailFieldIsActive, 
+            isDisabled: $vm.isViewingMode)
             .onSubmit {
                 vm.emailFieldIsActive = false
             }
             .padding(.horizontal)
     }
     var changePasswordButton: some View {
-        Button(action: vm.saveButtonTapped) {
+        Button(action: vm.editSaveButtonTapped) {
             Text(Str.updatePasswordTitle)
                 .frame(maxWidth: .infinity)
         }

--- a/iOS/FuFight/FuFight/Authentication/AuthenticationViewModel.swift
+++ b/iOS/FuFight/FuFight/Authentication/AuthenticationViewModel.swift
@@ -171,7 +171,7 @@ private extension AuthenticationViewModel {
         guard !topFieldHasError else {
             return updateError(MainError(type: .invalidUsername))
         }
-        let username = topFieldText
+        let username = topFieldText.trimmed
         Task {
             do {
                 ///Ensure non duplicated username
@@ -183,11 +183,11 @@ private extension AuthenticationViewModel {
                 updateLoadingMessage(to: Str.storingPhoto)
                 if let photoUrl = try await AccountNetworkManager.storePhoto(selectedImage, for: account.userId) {
                     updateLoadingMessage(to: Str.updatingUser)
-                    try await AccountNetworkManager.updateAuthenticatedAccount(username: username, photoURL: photoUrl)
+                    try await AccountNetworkManager.updateAuthenticatedUser(username: username, photoUrl: photoUrl)
                     account.username = username
                     account.photoUrl = photoUrl
                     updateLoadingMessage(to: Str.savingUser)
-                    try await AccountNetworkManager.setUsername(username, userId: account.userId, email: account.email ?? "")
+                    try await AccountNetworkManager.setUsername(username, userId: account.userId, email: account.email)
                     try await AccountNetworkManager.setData(account: account)
                     try await AccountManager.saveCurrent(account)
                     updateError(nil)

--- a/iOS/FuFight/FuFight/Helpers/ConstantTexts.swift
+++ b/iOS/FuFight/FuFight/Helpers/ConstantTexts.swift
@@ -33,6 +33,7 @@ struct Str {
     static let cancelTitle = "Cancel"
     static let saveTitle = "Save"
     static let deleteTitle = "Delete"
+    static let editTitle = "Edit"
 
     //Non- titles
     static let sendCode = "Send code"
@@ -52,8 +53,11 @@ struct Str {
     static let deletingStoredPhoto = "Deleting stored photo"
     static let deletingData = "Deleting user's data"
     static let deletingUser = "Deleting user"
+    static let updatingUsername = "Updating username"
     static let deletingUsername = "Deleting username"
     static let loggingOut = "Logging out"
     static let checkingUsername = "Checking username"
     static let fetchingEmail = "Fetching email"
+    static let usernameIsEmpty = "Username is empty"
+    static let emailIsEmpty = "Email is empty"
 }

--- a/iOS/FuFight/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
+++ b/iOS/FuFight/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
@@ -19,8 +19,11 @@ enum MainErrorType {
     case deletingUser
     case passwordReset
     case invalidEmail
+    case emptyEmail
     case invalidPassword
+    case emptyPassword
     case invalidUsername
+    case emptyUsername
     case notUniqueUsername
 
     var title: String {
@@ -53,6 +56,12 @@ enum MainErrorType {
             "Invalid username"
         case .notUniqueUsername:
             "Username is already taken"
+        case .emptyEmail:
+            "Email is empty"
+        case .emptyPassword:
+            "Password is empty"
+        case .emptyUsername:
+            "Username is empty"
         }
     }
 }

--- a/iOS/FuFight/FuFight/Helpers/CustomViews/UnderlinedTextField.swift
+++ b/iOS/FuFight/FuFight/Helpers/CustomViews/UnderlinedTextField.swift
@@ -95,14 +95,16 @@ struct UnderlinedTextField: View {
     @Binding var hasError: Bool
     ///isActive keeps track if this textfield is active and should ALWAYS be in sync with isFocused
     @Binding var isActive: Bool
+    @Binding var isDisabled: Bool
     @FocusState private var isFocused: Bool
     var trailingButtonAction: (() -> Void)?
 
-    init(type: Binding<FieldType>, text: Binding<String>, hasError: Binding<Bool>, isActive: Binding<Bool>, _ trailingButtonAction: (() -> Void)? = nil) {
+    init(type: Binding<FieldType>, text: Binding<String>, hasError: Binding<Bool>, isActive: Binding<Bool>, isDisabled: Binding<Bool> = .constant(false), _ trailingButtonAction: (() -> Void)? = nil) {
         self._type = type
         self._text = text
         self._hasError = hasError
         self._isActive = isActive
+        self._isDisabled = isDisabled
         self.trailingButtonAction = trailingButtonAction
     }
 
@@ -112,8 +114,10 @@ struct UnderlinedTextField: View {
                 Group {
                     if type == .password {
                         SecureField(type.placeHolder, text: $text)
+                            .foregroundStyle(isDisabled ? .secondary : .primary)
                     } else {
                         TextField(type.placeHolder, text: $text)
+                            .foregroundStyle(isDisabled ? .secondary : .primary)
                     }
                 }
                 .textFieldStyle(PlainTextFieldStyle())
@@ -135,9 +139,9 @@ struct UnderlinedTextField: View {
                 } label: {
                     switch type {
                     case .password, .phoneCode:
-                        Image(systemName: "eye")
+                        Image(systemName: "eye").tint(Color.label)
                     case .visiblePassword:
-                        Image(systemName: "eye.slash")
+                        Image(systemName: "eye.slash").tint(Color.label)
                     case .email, .emailOrUsername, .username, .phoneNumber, .unspecified:
                         Text("")
                             .hidden()
@@ -152,7 +156,7 @@ struct UnderlinedTextField: View {
                 
                 Rectangle()
                     .frame(height: 1.5)
-                    .foregroundStyle(hasError ? Color.red : Color.label)
+                    .foregroundStyle(hasError ? Color.red : (isDisabled ? Color.systemGray2 : Color.label))
             }
         )
         .onChange(of: text) {
@@ -161,5 +165,7 @@ struct UnderlinedTextField: View {
         .onChange(of: isActive) {
             isFocused = isActive
         }
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.8 : 1)
     }
 }


### PR DESCRIPTION
    - Turned email field’s eyeball from blue to black color
    - Add a way to reauthenticate user using email and password, update authenticated user’s password
    - Improved the way to update authenticated user’s data
    - Add a way to update auth user’s displayName, username in Accounts collection, and add new and delete old username in Usernames collection,
    -
    - Add a disabled look for UnderlinedTextField
    - Made sure all username are trimmed