### PR TITLE
Commit 1: Reauthenticate user before making account changes

### DIFF
--- a/iOS/FuFight/FuFight/Account/AccountView.swift
+++ b/iOS/FuFight/FuFight/Account/AccountView.swift
@@ -31,6 +31,11 @@ struct AccountView: View {
             }
             .alert(title: vm.alertTitle, message: vm.alertMessage, isPresented: $vm.isAlertPresented)
             .alert(title: Str.deleteAccountQuestion, primaryButton: AlertButton(type: .delete, action: vm.deleteAccount), secondaryButton: AlertButton(type: .secondaryCancel), isPresented: $vm.isDeleteAccountAlertPresented)
+            .alert(Str.logInAgainToMakeChanges, isPresented: $vm.isReauthenticationAlertPresented) {
+                SecureField(Str.enterPassword, text: $vm.password)
+                Button(Str.logInTitle, action: vm.reauthenticateUser)
+                Button(Str.cancelTitle, role: .cancel) { }
+            }
             .padding()
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -70,7 +75,7 @@ struct AccountView: View {
             hasError: $vm.usernameFieldHasError,
             isActive: $vm.usernameFieldIsActive, 
             isDisabled: $vm.isViewingMode) {
-                TODO("TODO: CHECK USERNAME HERE")
+                TODO("Is username unique?")
             }
             .onSubmit {
                 vm.usernameFieldIsActive = false
@@ -79,13 +84,8 @@ struct AccountView: View {
     var emailField: some View {
         UnderlinedTextField(
             type: .constant(.email),
-            text: $vm.emailFieldText,
-            hasError: $vm.emailFieldHasError,
-            isActive: $vm.emailFieldIsActive, 
-            isDisabled: $vm.isViewingMode)
-            .onSubmit {
-                vm.emailFieldIsActive = false
-            }
+            text: .constant(Account.current?.email ?? ""),
+            isDisabled: .constant(true))
     }
     var changePasswordButton: some View {
         NavigationLink {
@@ -97,9 +97,7 @@ struct AccountView: View {
         .appButton(.primary)
     }
     var deleteAccountButton: some View {
-        Button {
-            vm.isDeleteAccountAlertPresented = true
-        } label: {
+        Button(action: vm.deleteButtonTapped) {
             Text(Str.deleteTitle)
                 .frame(maxWidth: .infinity)
         }

--- a/iOS/FuFight/FuFight/Account/UpdatePassword/UpdatePasswordViewModel.swift
+++ b/iOS/FuFight/FuFight/Account/UpdatePassword/UpdatePasswordViewModel.swift
@@ -71,7 +71,7 @@ private extension UpdatePasswordViewModel {
                 LOGD("Finished updating password for \(auth.currentUser!.displayName!)")
                 dismissView()
             } catch {
-                updateError(MainError(type: .deletingUser, message: error.localizedDescription))
+                updateError(MainError(type: .reauthenticatingUser, message: error.localizedDescription))
             }
         }
     }

--- a/iOS/FuFight/FuFight/Helpers/ConstantTexts.swift
+++ b/iOS/FuFight/FuFight/Helpers/ConstantTexts.swift
@@ -44,20 +44,22 @@ struct Str {
     static let saveTitle = "Save"
     static let deleteTitle = "Delete"
     static let editTitle = "Edit"
+    static let finishTitle = "Finish"
 
     //Non- titles
     static let sendCode = "Send code"
     static let verifyCode = "Verify code"
     static let dontHaveAnAccount = "Don't have an account? Sign up."
     static let alreadyHaveAnAccount = "Already have an account? Log in."
-    static let finishTitle = "Finish"
     static let enterYourEmail = "Enter your email"
+    static let logInAgainToMakeChanges = "Log in again to make account changes"
 
     //MARK: - Logs
     static let loggingIn = "Logging in"
     static let fetchingUserData = "Fetching user's data"
     static let savingUser = "Saving user"
     static let updatingUser = "Updating user"
+    static let updatingAuthenticatedUser = "Updating authenticated user"
     static let creatingUser = "Creating user"
     static let storingPhoto = "Storing photo"
     static let deletingStoredPhoto = "Deleting stored photo"

--- a/iOS/FuFight/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
+++ b/iOS/FuFight/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
@@ -25,6 +25,7 @@ enum MainErrorType {
     case invalidUsername
     case emptyUsername
     case notUniqueUsername
+    case reauthenticatingUser
 
     var title: String {
         switch self {
@@ -62,6 +63,8 @@ enum MainErrorType {
             "Password is empty"
         case .emptyUsername:
             "Username is empty"
+        case .reauthenticatingUser:
+            "Error reauthenticating user"
         }
     }
 }

--- a/iOS/FuFight/FuFight/Helpers/CustomViews/UnderlinedTextField.swift
+++ b/iOS/FuFight/FuFight/Helpers/CustomViews/UnderlinedTextField.swift
@@ -148,7 +148,7 @@ struct UnderlinedTextField: View {
 
     @FocusState private var isFocused: Bool
 
-    init(type: Binding<FieldType>, text: Binding<String>, isSecure: Binding<Bool> = .constant(false), hasError: Binding<Bool>, isActive: Binding<Bool>, isDisabled: Binding<Bool> = .constant(false), showTitle: Bool = true, _ trailingButtonAction: (() -> Void)? = nil) {
+    init(type: Binding<FieldType>, text: Binding<String>, isSecure: Binding<Bool> = .constant(false), hasError: Binding<Bool> = .constant(false), isActive: Binding<Bool> = .constant(false), isDisabled: Binding<Bool> = .constant(false), showTitle: Bool = true, _ trailingButtonAction: (() -> Void)? = nil) {
         self._type = type
         self._text = text
         self._isSecure = isSecure


### PR DESCRIPTION
    - Remove updating email code
    - Show reauthenticate alert if needed before deleting account
    - Show reauthenticate alert if needed when edit button is tapped
    - Only show loading messages and save user when there is an actual change