### PR TITLE
Commit 1: Create and show an empty GameView and GameOverView

### DIFF
--- a/iOS/FuFight/FuFight/Game/GameOver/GameOverView.swift
+++ b/iOS/FuFight/FuFight/Game/GameOver/GameOverView.swift
@@ -1,0 +1,49 @@
+//
+//  GameOverView.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 3/4/24.
+//
+
+import SwiftUI
+
+struct GameOverView: View {
+    @State var vm = GameOverViewModel()
+    @Binding var path: NavigationPath
+
+    var body: some View {
+        VStack(spacing: 0) {
+
+            VStack(spacing: 12) {
+                Button("Go to home") {
+                    path.removeLast(path.count)
+                }
+            }
+        }
+        .alert(title: vm.alertTitle,
+               message: vm.alertMessage,
+               isPresented: $vm.isAlertPresented)
+        .padding(.horizontal, horizontalPadding)
+        .overlay {
+            if let message = vm.loadingMessage {
+                ProgressView(message)
+            }
+        }
+        .onAppear {
+            vm.onAppear()
+        }
+        .onDisappear {
+            vm.onDisappear()
+        }
+        .allowsHitTesting(vm.loadingMessage == nil)
+        .navigationTitle("Game Over")
+    }
+}
+
+#Preview {
+    @State var path: NavigationPath = NavigationPath()
+
+    return NavigationView {
+        GameOverView(path: $path)
+    }
+}

--- a/iOS/FuFight/FuFight/Game/GameOver/GameOverViewModel.swift
+++ b/iOS/FuFight/FuFight/Game/GameOver/GameOverViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  GameOverViewModel.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 3/4/24.
+//
+
+import SwiftUI
+
+@Observable
+class GameOverViewModel: BaseViewModel {
+
+    override func onAppear() {
+        super.onAppear()
+    }
+
+    //MARK: - Public Methods
+}
+
+//MARK: - Private Methods
+private extension GameOverViewModel {
+
+}

--- a/iOS/FuFight/FuFight/Game/GameRoute.swift
+++ b/iOS/FuFight/FuFight/Game/GameRoute.swift
@@ -1,0 +1,13 @@
+//
+//  GameRoute.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 3/4/24.
+//
+
+import Foundation
+
+enum GameRoute: String {
+    case game
+    case gameOver
+}

--- a/iOS/FuFight/FuFight/Game/GameView/GameView.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/GameView.swift
@@ -1,0 +1,51 @@
+//
+//  GameView.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 3/4/24.
+//
+
+import SwiftUI
+
+struct GameView: View {
+    @Binding var path: NavigationPath
+    @State var vm = GameViewModel()
+    
+    var body: some View {
+        VStack(spacing: 0) {
+
+            VStack(spacing: 12) {
+                Button {
+                    path.append(GameRoute.gameOver)
+                } label: {
+                    Text("Game over")
+                }
+            }
+        }
+        .alert(title: vm.alertTitle,
+               message: vm.alertMessage,
+               isPresented: $vm.isAlertPresented)
+        .padding(.horizontal, horizontalPadding)
+        .overlay {
+            if let message = vm.loadingMessage {
+                ProgressView(message)
+            }
+        }
+        .onAppear {
+            vm.onAppear()
+        }
+        .onDisappear {
+            vm.onDisappear()
+        }
+        .allowsHitTesting(vm.loadingMessage == nil)
+        .navigationTitle("Game View")
+    }
+}
+
+#Preview {
+    @State var path: NavigationPath = NavigationPath()
+
+    return NavigationView {
+        GameView(path: $path)
+    }
+}

--- a/iOS/FuFight/FuFight/Game/GameView/GameViewModel.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/GameViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  GameViewModel.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 3/4/24.
+//
+
+import SwiftUI
+
+@Observable
+class GameViewModel: BaseViewModel {
+
+    override func onAppear() {
+        super.onAppear()
+    }
+
+    //MARK: - Public Methods
+}
+
+//MARK: - Private Methods
+private extension GameViewModel {
+
+}

--- a/iOS/FuFight/FuFight/Home/HomeView.swift
+++ b/iOS/FuFight/FuFight/Home/HomeView.swift
@@ -11,17 +11,14 @@ struct HomeView: View {
     @State var vm: HomeViewModel
 
     var body: some View {
-        NavigationView {
+        NavigationStack(path: $vm.path) {
             ScrollView {
                 VStack {
-
                     Text("Welcome \(vm.account.displayName)")
 
                     Spacer()
 
-                    Button("Play") {
-                        TODO("Play")
-                    }
+                    playButton
                 }
                 .alert(title: vm.alertTitle, message: vm.alertMessage, isPresented: $vm.isAlertPresented)
                 .padding()
@@ -34,6 +31,14 @@ struct HomeView: View {
             .overlay {
                 if let message = vm.loadingMessage {
                     ProgressView(message)
+                }
+            }
+            .navigationDestination(for: GameRoute.self) { route in
+                switch route {
+                case .game:
+                    GameView(path: $vm.path)
+                case .gameOver:
+                    GameOverView(path: $vm.path)
                 }
             }
         }
@@ -50,6 +55,14 @@ struct HomeView: View {
     var accountImage: some View {
         NavigationLink(destination: AccountView(vm: AccountViewModel(account: vm.account))) {
             AccountImage(url: vm.account.photoUrl, radius: 30)
+        }
+    }
+
+    var playButton: some View {
+        Button {
+            vm.path.append(GameRoute.game)
+        } label: {
+            Text("Start game")
         }
     }
 }

--- a/iOS/FuFight/FuFight/Home/HomeViewModel.swift
+++ b/iOS/FuFight/FuFight/Home/HomeViewModel.swift
@@ -11,6 +11,7 @@ import FirebaseAuth
 @Observable
 class HomeViewModel: BaseAccountViewModel {
     var isAccountVerified = false
+    var path = NavigationPath()
 
     //MARK: - ViewModel Overrides
 


### PR DESCRIPTION
    - Created views and view model
    - Add a way to transition from `HomeView` to `GameView` to `GameOverView` and popBack to `HomeView` by changing HomeView’s `NavigationView` into `NavigationStack` and using `NavigationPath`