### PR TITLE
Commit 2: Apply damage boost to attacks and indicate with fire

### DIFF
--- a/iOS/FuFight/FuFight/Game/GameView/Model/Attack.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Attack.swift
@@ -14,6 +14,10 @@ enum AttackPosition: Int {
     case rightMedium = 4
     case leftHard = 5
     case rightHard = 6
+
+    var isLeft: Bool {
+        return rawValue % 2 == 1
+    }
 }
 
 protocol AttackProtocol: MoveProtocol {
@@ -25,6 +29,8 @@ protocol AttackProtocol: MoveProtocol {
     var damageReduction: Double { get }
     ///Position of the attack in the view
     var position: AttackPosition { get }
+    ///Returns true if attack can increase next attack's damage
+    var canBoost: Bool { get }
 }
 
 
@@ -33,6 +39,9 @@ struct Attack {
     private(set) var cooldown: Int = 0
     private(set) var state: MoveButtonState = .initial
     private(set) var fireState: FireState? = nil
+    var isAvailableNextTurn: Bool {
+        return cooldown <= 1
+    }
 
     init(_ move: any AttackProtocol) {
         self.move = move
@@ -58,6 +67,11 @@ struct Attack {
     mutating func restart() {
         cooldown = 0
         setStateTo(.initial)
+        setFireTo(nil)
+    }
+
+    mutating func setFireTo(_ newFireState: FireState?) {
+        self.fireState = newFireState
     }
 }
 
@@ -65,12 +79,12 @@ enum FireState {
     case small
     case big
 
-    var imageView: GIFView {
+    var boostMultiplier: CGFloat {
         switch self {
         case .small:
-            GIFView(type: URLType.name("weakRedFire"))
+            0.2
         case .big:
-            GIFView(type: URLType.name("strongRedFire"))
+            0.35
         }
     }
 }

--- a/iOS/FuFight/FuFight/Game/GameView/Model/Player.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Player.swift
@@ -1,0 +1,134 @@
+//
+//  Player.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 3/11/24.
+//
+
+import Foundation
+
+@Observable
+class Player {
+    var photoUrl: URL
+    var username: String
+    var hp: CGFloat
+    let maxHp: CGFloat
+    var attacks: [Attack]
+    var defenses: [Defend]
+    var turns: [Turn] = []
+    var hasSpeedBoost: Bool = false
+    var boostLevel = 0
+
+    var isDead: Bool {
+        hp <= 0
+    }
+
+    init(photoUrl: URL, username: String, hp: CGFloat, maxHp: CGFloat, attacks: [Attack], defenses: [Defend], turns: [Turn] = [], hasSpeedBoost: Bool = false, boostLevel: Int = 0) {
+        self.photoUrl = photoUrl
+        self.username = username
+        self.hp = hp
+        self.maxHp = maxHp
+        self.attacks = attacks
+        self.defenses = defenses
+        self.turns = turns
+        self.hasSpeedBoost = hasSpeedBoost
+        self.boostLevel = boostLevel
+    }
+
+    func prepareForNextRound() {
+        var turn = Turn(round: turns.count + 1, hasSpeedBoost: hasSpeedBoost)
+        updateAttacksState(attacks: &attacks, turn: &turn)
+        updateFireState(attacks: &attacks, turn: &turn, boostLevel: &boostLevel)
+        updateDefensesState(defenses: &defenses, turn: &turn)
+        turns.append(turn)
+    }
+
+    func prepareForRematch() {
+        hp = maxHp
+        for index in attacks.indices {
+            attacks[index].restart()
+        }
+        for index in defenses.indices {
+            defenses[index].restart()
+        }
+        turns.removeAll()
+    }
+}
+
+private extension Player {
+    func updateFireState(attacks: inout [Attack], turn: inout Turn, boostLevel: inout Int) {
+        if let selectedAttack = turn.attack,
+           selectedAttack.fireState != .big {
+            boostLevel += 1
+            let isMaxBoost = boostLevel > 1
+            for (index, attack) in attacks.enumerated() {
+                switch attacks[index].state {
+                case .selected, .cooldown, .unselected:
+                    continue
+                case .initial:
+                    ///This works because all of attacks's state are either in cooldown or initial
+                    if selectedAttack.move.canBoost {
+                        if !isMaxBoost {
+                            ///Do not boost the hard attacks on stage 1 boost
+                            let indexOfHardAttacks: [AttackPosition] = [.rightHard, .leftHard]
+                            if !indexOfHardAttacks.contains(attacks[index].move.position) {
+                                if attack.move.canBoost {
+                                    attacks[index].setFireTo(.small)
+                                } else {
+                                    attacks[index].setFireTo(.big)
+                                }
+                            } else {
+                                attacks[index].setFireTo(nil)
+                            }
+                        } else {
+                            ///If stage 2 boost, then make all available attacks have a big fire
+                            attacks[index].setFireTo(.big)
+                        }
+                    } else {
+                        removeAllFires()
+                    }
+                }
+            }
+            if isMaxBoost {
+                boostLevel = 0
+            }
+        } else {
+            removeAllFires()
+        }
+
+        func removeAllFires() {
+            boostLevel = 0
+            attacks.indices.forEach {
+                attacks[$0].setFireTo(nil)
+            }
+        }
+    }
+
+    func updateAttacksState(attacks: inout [Attack], turn: inout Turn) {
+        for index in attacks.indices {
+            switch attacks[index].state {
+            case .selected:
+                attacks[index].setStateTo(.cooldown)
+                turn.update(attacks[index])
+            case .cooldown:
+                attacks[index].reduceCooldown()
+            case .initial, .unselected:
+                attacks[index].setStateTo(.initial)
+            }
+        }
+    }
+
+    func updateDefensesState(defenses: inout [Defend], turn: inout Turn) {
+        for index in defenses.indices {
+            switch defenses[index].state {
+            case .selected:
+                defenses[index].setStateTo(.cooldown)
+                turn.update(defenses[index])
+            case .cooldown:
+                defenses[index].reduceCooldown()
+            case .initial, .unselected:
+                defenses[index].setStateTo(.initial)
+            }
+        }
+    }
+}

--- a/iOS/FuFight/FuFight/Game/GameView/Model/Punch.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Punch.swift
@@ -7,14 +7,17 @@
 
 import SwiftUI
 
-enum Punch: String, CaseIterable, AttackProtocol {
+enum Punch: String, CaseIterable {
     case leftPunchLight
     case leftPunchMedium
     case leftPunchHard
     case rightPunchLight
     case rightPunchMedium
     case rightPunchHard
+}
 
+//MARK: MoveProtocol extension 
+extension Punch {
     var id: String {
         rawValue
     }
@@ -59,6 +62,31 @@ enum Punch: String, CaseIterable, AttackProtocol {
 
     var moveType: MoveType { .attack }
 
+    var padding: Double {
+        switch self {
+        case .leftPunchLight, .rightPunchLight:
+            24
+        case .leftPunchMedium, .rightPunchMedium:
+            20
+        case .leftPunchHard, .rightPunchHard:
+            18
+        }
+    }
+
+    var cooldown: Int {
+        switch self {
+        case .leftPunchLight, .rightPunchLight:
+            1
+        case .leftPunchMedium, .rightPunchMedium:
+            2
+        case .leftPunchHard, .rightPunchHard:
+            3
+        }
+    }
+}
+
+//MARK: AttackProtocol extension
+extension Punch: AttackProtocol {
     var damage: Double {
         switch self {
         case .leftPunchLight, .rightPunchLight:
@@ -92,17 +120,6 @@ enum Punch: String, CaseIterable, AttackProtocol {
         }
     }
 
-    var padding: Double {
-        switch self {
-        case .leftPunchLight, .rightPunchLight:
-            24
-        case .leftPunchMedium, .rightPunchMedium:
-            20
-        case .leftPunchHard, .rightPunchHard:
-            18
-        }
-    }
-
     var position: AttackPosition {
         switch self {
         case .leftPunchLight:
@@ -120,14 +137,12 @@ enum Punch: String, CaseIterable, AttackProtocol {
         }
     }
 
-    var cooldown: Int {
+    var canBoost: Bool {
         switch self {
-        case .leftPunchLight, .rightPunchLight:
-            1
-        case .leftPunchMedium, .rightPunchMedium:
-            2
-        case .leftPunchHard, .rightPunchHard:
-            3
+        case .leftPunchLight, .rightPunchLight, .rightPunchMedium:
+            true
+        case .leftPunchMedium, .leftPunchHard, .rightPunchHard:
+            false
         }
     }
 }

--- a/iOS/FuFight/FuFight/Game/GameView/Model/Turn.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Turn.swift
@@ -1,0 +1,52 @@
+//
+//  Turn.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 3/11/24.
+//
+
+import Foundation
+
+class Turn {
+    private(set) var round: Int
+    private(set) var attack: Attack?
+    private(set) var defend: (Defend)?
+    private(set) var speed: CGFloat = 0
+    private(set) var hasSpeedBoost: Bool
+
+    init(round: Int, hasSpeedBoost: Bool) {
+        self.round = round
+        self.attack = nil
+        self.defend = nil
+        self.speed = 0
+        self.hasSpeedBoost = hasSpeedBoost
+    }
+
+    init(round: Int, attacks: [Attack], defenses: [Defend], hasSpeedBoost: Bool) {
+        self.round = round
+        self.attack = attacks.first { $0.state == .selected }
+        self.defend = defenses.first { $0.state == .selected }
+        self.hasSpeedBoost = hasSpeedBoost
+        self.speed = 0
+        updateSpeed()
+    }
+
+    func update(_ attack: Attack?) {
+        self.attack = attack
+        updateSpeed()
+    }
+
+    func update(_ defend: Defend?) {
+        self.defend = defend
+        updateSpeed()
+    }
+}
+
+private extension Turn {
+    func updateSpeed() {
+        let moveSpeed = attack?.move.speed ?? 0
+        let speedMultiplier = defend?.move.speedMultiplier ?? 0
+        let speedBoostMultiplier = hasSpeedBoost ? 0.1 : 0
+        speed = moveSpeed * (1 + speedMultiplier) * (1 + speedBoostMultiplier)
+    }
+}


### PR DESCRIPTION
    - Created fireState image from FireState enum
    - Came up with a damage boost game logic to determine which attacks get boosted
    - Put fire gifs visually to know which attacks are getting boosted
    - Apply fire boost to damage applied
        - Fixed game damage calculations not being applied correctly for damage reduction
        - Refactored to have a function to calculate damage
    - Put Player and Turn in its own file
    - Fixed didLand() logic