### PR TITLE
Commit 4: Showing damages

### DIFF
--- a/iOS/FuFight/FuFight/Game/GameView/Model/Player.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Player.swift
@@ -11,15 +11,14 @@ import Foundation
 class Player {
     private(set) var photoUrl: URL
     private(set) var username: String
-    var hp: CGFloat
+    private(set) var hp: CGFloat
     let maxHp: CGFloat
     var attacks: [Attack]
     var defenses: [Defend]
     private(set) var turns: [Turn] = []
-    var hasSpeedBoost: Bool = false
     private(set) var boostLevel = 0
     private(set) var didMissAttack = false
-
+    private(set) var hasSpeedBoost = false
     var isDead: Bool {
         hp <= 0
     }
@@ -32,7 +31,6 @@ class Player {
         self.attacks = attacks
         self.defenses = defenses
         self.turns = turns
-        self.hasSpeedBoost = hasSpeedBoost
         self.boostLevel = boostLevel
     }
 
@@ -59,6 +57,23 @@ class Player {
 
     func attackMissed() {
         didMissAttack = true
+        turns.last?.updateTotalDamage(to: nil)
+    }
+
+    func giveSpeedBoost(_ shouldSpeedBoost: Bool) {
+        hasSpeedBoost = shouldSpeedBoost
+        if turns.last != nil {
+            turns.last!.hasSpeedBoost = shouldSpeedBoost
+        }
+    }
+
+    func damage(amount: CGFloat) {
+        hp -= amount
+        turns.last?.updateTotalDamage(to: amount)
+    }
+
+    func gameOver() {
+        hp = 0
     }
 }
 
@@ -117,7 +132,7 @@ private extension Player {
             switch attacks[index].state {
             case .selected:
                 attacks[index].setStateTo(.cooldown)
-                turn.update(attacks[index])
+                turn.update(attack: attacks[index])
             case .cooldown:
                 attacks[index].reduceCooldown()
             case .initial, .unselected:
@@ -131,7 +146,7 @@ private extension Player {
             switch defenses[index].state {
             case .selected:
                 defenses[index].setStateTo(.cooldown)
-                turn.update(defenses[index])
+                turn.update(defend: defenses[index])
             case .cooldown:
                 defenses[index].reduceCooldown()
             case .initial, .unselected:

--- a/iOS/FuFight/FuFight/Game/GameView/Model/Turn.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Turn.swift
@@ -12,7 +12,10 @@ class Turn {
     private(set) var attack: Attack?
     private(set) var defend: (Defend)?
     private(set) var speed: CGFloat = 0
-    private(set) var hasSpeedBoost: Bool
+    ///True if user on this turn had the speed boost
+    var hasSpeedBoost: Bool
+    ///nil means no attack selected, 0 means dodged
+    private(set) var totalDamage: CGFloat? = 0
 
     init(round: Int, hasSpeedBoost: Bool) {
         self.round = round
@@ -31,14 +34,18 @@ class Turn {
         updateSpeed()
     }
 
-    func update(_ attack: Attack?) {
+    func update(attack: Attack?) {
         self.attack = attack
         updateSpeed()
     }
 
-    func update(_ defend: Defend?) {
+    func update(defend: Defend?) {
         self.defend = defend
         updateSpeed()
+    }
+
+    func updateTotalDamage(to amount: CGFloat?) {
+        self.totalDamage = amount
     }
 }
 
@@ -48,5 +55,15 @@ private extension Turn {
         let speedMultiplier = defend?.move.speedMultiplier ?? 0
         let speedBoostMultiplier = hasSpeedBoost ? 0.1 : 0
         speed = moveSpeed * (1 + speedMultiplier) * (1 + speedBoostMultiplier)
+    }
+}
+
+extension Turn: Equatable, Hashable {
+    static func == (lhs: Turn, rhs: Turn) -> Bool {
+        return lhs.round == rhs.round
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        return hasher.combine(round)
     }
 }

--- a/iOS/FuFight/FuFight/Game/GameView/Views/PlayerView.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Views/PlayerView.swift
@@ -88,24 +88,55 @@ struct PlayerView: View {
 
     var nameView: some View {
         HStack {
-            if isEnemy && player.hasSpeedBoost {
-                statusView
+            if isEnemy {
+                if !player.turns.isEmpty {
+                    damagesList
+                }
+
+                if player.hasSpeedBoost {
+                    plusImage
+                        .frame(width: 20, height: 20)
+                }
             }
 
             Text(player.username)
                 .font(mediumTextFont)
                 .foregroundStyle(.white)
 
-            if !isEnemy && player.hasSpeedBoost {
-                statusView
+            if !isEnemy {
+                if player.hasSpeedBoost {
+                    plusImage
+                        .frame(width: 20, height: 20)
+                }
+
+                if !player.turns.isEmpty {
+                    damagesList
+                }
             }
         }
     }
 
-    var statusView: some View {
-        HStack {
-            plusImage
-                .frame(width: 20, height: 20)
+    var damagesList: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 20) {
+                ForEach(player.turns.dropLast().reversed(), id: \.round) { turn in
+                    Group {
+                        if let damage = turn.totalDamage {
+                            if damage <= 0 {
+                                Text("Round \(turn.round): N/A")
+                                    .foregroundStyle(.white)
+                            } else {
+                                Text("Round \(turn.round): \(damage.intString)")
+                                    .foregroundStyle(.red)
+                            }
+                        } else {
+                            Text("Round \(turn.round): Dodged")
+                                .foregroundStyle(.white)
+                        }
+                    }
+                    .font(mediumTextFont)
+                }
+            }
         }
     }
 }

--- a/iOS/FuFight/FuFight/Helpers/Extensions/CGFloat+Extensions.swift
+++ b/iOS/FuFight/FuFight/Helpers/Extensions/CGFloat+Extensions.swift
@@ -1,0 +1,14 @@
+//
+//  CGFloat+Extensions.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 3/11/24.
+//
+
+import Foundation
+
+extension CGFloat {
+    var intString: String {
+        return String(format: "%.0f", self)
+    }
+}


### PR DESCRIPTION
    - Add totalDamage to Turns which can be nil if dodged
    - Show damages each round in PlayerView from player’s turns
        - Reversed/rotated for enemy’s playerView
        - Do not show the damage of the current round until next round
    - Cleared statuses when restarting the game
    - Added access type on Turns and Player properties