### PR TITLE
Commit 16: Add an indicator if attack can boost next round’s attack

### DIFF
--- a/iOS/FuFight-Old/FuFight/Game/GameView/Views/AttackButton.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Views/AttackButton.swift
@@ -51,6 +51,21 @@ struct AttackButton: View {
             .overlay {
                 MoveStateView(state: move.state, cooldown: move.currentCooldown, playerType: playerType)
             }
+            .overlay {
+                if move.canBoost {
+                    switch move.state {
+                    case .cooldown:
+                        EmptyView()
+                    case .initial, .unselected, .selected:
+                        switch move.fireState {
+                        case .initial:
+                            AttackCanBoostView(playerType: playerType)
+                        case .small, .big:
+                            EmptyView()
+                        }
+                    }
+                }
+            }
     }
 }
 

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Views/AttackCanBoostView.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Views/AttackCanBoostView.swift
@@ -1,0 +1,59 @@
+//
+//  AttackCanBoostView.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 5/15/24.
+//
+
+import SwiftUI
+
+struct AttackCanBoostView: View {
+    let playerType: PlayerType
+
+    @State private var isShowingCanBoostIndicator: Bool = false
+    @State private var moveClockwise: Bool = false
+    private var strokeWidth: CGFloat {
+        playerType.shouldFlip ? 1 : 2
+    }
+    private var spinDuration: CGFloat {
+        playerType.shouldFlip ? 1.0 : 1.75
+    }
+    private var size: CGFloat {
+        strokeWidth * 2
+    }
+    private var xOffset: CGFloat {
+        playerType.isEnemy ? -9 : -45
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(.yellow, lineWidth: strokeWidth)
+                .opacity(isShowingCanBoostIndicator ?  1 : 0)
+                .zIndex(1)
+                .onAppear(delay: 0.5) {
+                    let boostIndicatorAnimation = Animation.easeInOut(duration: 1).repeatForever(autoreverses: true)
+                    withAnimation(boostIndicatorAnimation) {
+                        isShowingCanBoostIndicator.toggle()
+                    }
+                }
+
+            Circle()
+                .fill(.yellow)
+                .frame(width: size, height: size, alignment: .center)
+                .offset(x: xOffset)
+                .rotationEffect(.degrees(moveClockwise ? 360 : 0))
+                .animation(.linear(duration: spinDuration).repeatForever(autoreverses: false),
+                           value: moveClockwise
+                )
+                .opacity(isShowingCanBoostIndicator ?  1 : 0.3)
+        }
+        .onAppear {
+            self.moveClockwise.toggle()
+        }
+    }
+}
+
+#Preview {
+    AttackCanBoostView(playerType: .user)
+}


### PR DESCRIPTION
    - Created `AttackCanBoostView` to overlay on the `AttackButton` if attack’s is not in cooldown and in `.initial` `FireState`
    - `AttackCanBoostView` has a circle stroke around the button and a circle spinning linearly along the stroke path