### PR TITLE
Commit 2: Create and show GameLoadingView (5/16)

### DIFF
--- a/iOS/FuFight-Old/FuFight/Game/GameRoute.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameRoute.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 enum GameRoute: String {
-    case game
+    case loading
+    case onlineGame
+    case offlineGame
     case practice
 }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameLoadingView.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameLoadingView.swift
@@ -1,0 +1,83 @@
+//
+//  GameLoadingView.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 5/16/24.
+//
+
+import SwiftUI
+
+struct GameLoadingView: View {
+    @Binding var path: NavigationPath
+    @State var vm: GameLoadingViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                Spacer()
+
+
+            }
+            .alert(title: vm.alertTitle,
+                   message: vm.alertMessage,
+                   isPresented: $vm.isAlertPresented)
+            .padding(.horizontal, horizontalPadding)
+        }
+        .overlay {
+            if let message = vm.loadingMessage {
+                ProgressView(message)
+            }
+        }
+        .onAppear {
+            vm.onAppear()
+        }
+        .onDisappear {
+            vm.onDisappear()
+        }
+        .allowsHitTesting(vm.loadingMessage == nil)
+        .background(
+            backgroundImage
+                .padding(.trailing, 400)
+        )
+        .safeAreaInset(edge: .bottom) {
+            cancelButton
+        }
+        .navigationBarHidden(true)
+        .frame(maxWidth: .infinity)
+        .onAppear(delay: 3) {
+            vm.updateLoadingMessage(to: nil)
+
+            runAfterDelay(delay: 0.2) {
+                self.path.append(GameRoute.onlineGame)
+            }
+        }
+    }
+
+    var cancelButton: some View {
+        Button {
+            transitionBackToHome()
+        } label: {
+            Text("Cancel")
+                .padding(6)
+                .frame(maxWidth: .infinity)
+                .foregroundStyle(Color(uiColor: .systemBackground))
+                .font(.title)
+                .background(Color(uiColor: .label))
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 4)
+    }
+}
+
+private extension GameLoadingView {
+    func transitionBackToHome() {
+        path.removeLast(path.count)
+    }
+}
+
+#Preview {
+    @State var path: NavigationPath = NavigationPath()
+
+    return GameLoadingView(path: $path, vm: GameLoadingViewModel(player: fakeEnemyPlayer))
+}

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameLoadingViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameLoadingViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  GameLoadingViewModel.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 5/16/24.
+//
+
+import SwiftUI
+import FirebaseAuth
+
+@Observable
+class GameLoadingViewModel: BaseViewModel {
+    var player: Player
+    var enemyPlayer: Player?
+
+    init(player: Player, enemyPlayer: Player? = nil) {
+        self.player = player
+        self.enemyPlayer = enemyPlayer
+    }
+
+    //MARK: - ViewModel Overrides
+
+    override func onAppear() {
+        super.onAppear()
+        updateLoadingMessage(to: "Finding")
+    }
+
+    //MARK: - Public Methods
+}
+
+//MARK: - Private Methods
+private extension GameLoadingViewModel {
+
+}

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameView.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameView.swift
@@ -40,11 +40,11 @@ struct GameView: View {
                isPresented: $vm.isAlertPresented)
         .alert(title: vm.player.isDead ? "You lost" : "You won!",
                primaryButton: AlertButton(title: "Rematch", action: vm.rematch),
-               secondaryButton: AlertButton(title: "Go home", action: { path.removeLast(path.count) }),
+               secondaryButton: AlertButton(title: "Go home", action: transitionBackToHome),
                isPresented: .constant(vm.state == .gameOver))
         .alert(title: "Game is paused",
                primaryButton: AlertButton(title: "Resume", action: {}),
-               secondaryButton: AlertButton(title: "Exit", action: { path.removeLast(path.count) }),
+               secondaryButton: AlertButton(title: "Exit", action: transitionBackToHome),
                isPresented: $vm.isGamePaused)
         .overlay {
             timerView
@@ -108,10 +108,16 @@ struct GameView: View {
     }
 }
 
+private extension GameView {
+    func transitionBackToHome() {
+        path.removeLast(path.count)
+    }
+}
+
 #Preview {
     @State var path: NavigationPath = NavigationPath()
 
     return NavigationView {
-        GameView(path: $path, vm: GameViewModel(isPracticeMode: true))
+        GameView(path: $path, vm: GameViewModel(isPracticeMode: true, player: fakePlayer, enemyPlayer: fakeEnemyPlayer))
     }
 }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
@@ -37,19 +37,11 @@ class GameViewModel: BaseViewModel {
     var secondAttackerDamageDealtReduction: CGFloat = 0
     var secondAttackerDelay: CGFloat = 0
 
-    init(isPracticeMode: Bool) {
+    init(isPracticeMode: Bool, player: Player, enemyPlayer: Player) {
         self.state = .starting
         self.isPracticeMode = isPracticeMode
-        let photoUrl = Account.current?.photoUrl ?? fakePhotoUrl
-
-        self.player = Player(photoUrl: photoUrl,
-                             username: Account.current?.displayName ?? "",
-                             hp: defaultMaxHp,
-                             maxHp: defaultMaxHp,
-                             fighter: Fighter(type: .samuel, isEnemy: false),
-                             state: PlayerState(boostLevel: .none, hasSpeedBoost: false),
-                             moves: Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses))
-        self.enemyPlayer = fakeEnemyPlayer
+        self.player = player
+        self.enemyPlayer = enemyPlayer
         super.init()
     }
 
@@ -201,7 +193,7 @@ private extension GameViewModel {
         //Get the damage results
         let attackResult = GameService.getAttackResult(attackerRound: attacker.currentRound, defenderRound: defender.currentRound, defenderHp: defender.hp, damageReduction: secondAttackerDamageDealtReduction)
 
-        LOGD("AttackingHandler \(attacker.fighter.fighterType.name) (\(attacker.speed)) with \(attacker.currentRound.attack?.name ?? "no attack") \t\t vs \(defender.currentRound.defend?.name ?? "no defense") \t\t\(attackResult)")
+        LOGD("AttackHandler \(attacker.fighter.fighterType.name) (\(attacker.speed)) with \(attacker.currentRound.attack?.name ?? "no attack") \t\t vs \(defender.currentRound.defend?.name ?? "no defense") \t\t\(attackResult)")
 
         //Update attacker based on results
         if attackResult.didAttackLand {

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
@@ -32,7 +32,7 @@ struct PlayerState {
 
 @Observable
 class Player {
-    private(set) var photoUrl: URL
+    private(set) var photoUrl: URL?
     private(set) var username: String
     private(set) var hp: CGFloat
     private(set) var maxHp: CGFloat

--- a/iOS/FuFight-Old/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/Constants/Constants.swift
@@ -112,18 +112,18 @@ let defaultAllDashDefenses: [Defense] = Dash.allCases.compactMap { Defense($0) }
 ///Speed multiplier for the player that has the speed boost
 let speedBoostMultiplier: CGFloat = 1.1
 
-//let fakePlayer = Player(photoUrl: fakePhotoUrl,
-//                        username: "Samuel",
-//                        hp: defaultMaxHp,
-//                        maxHp: defaultMaxHp,
-//                        fighter: Fighter(type: .bianca, isEnemy: false),
-//                        state: PlayerState(boostLevel: .none, hasSpeedBoost: false),
-//                        moves: Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses))
+let fakePlayer = Player(photoUrl: fakePhotoUrl,
+                        username: "Samuel",
+                        hp: defaultMaxHp,
+                        maxHp: defaultMaxHp,
+                        fighter: Fighter(type: .samuel, isEnemy: false),
+                        state: PlayerState(boostLevel: .none, hasSpeedBoost: false),
+                        moves: Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses))
 let fakeEnemyPlayer = Player(photoUrl: fakePhotoUrl,
                              username: "Zoro",
                              hp: defaultEnemyHp,
                              maxHp: defaultEnemyHp,
-                             fighter: Fighter(type: .samuel, isEnemy: true),
+                             fighter: Fighter(type: .clara, isEnemy: true),
                              state: PlayerState(boostLevel: .none, hasSpeedBoost: false),
                              moves: Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses))
 

--- a/iOS/FuFight-Old/FuFight/Home/HomeView.swift
+++ b/iOS/FuFight-Old/FuFight/Home/HomeView.swift
@@ -42,10 +42,16 @@ struct HomeView: View {
             }
             .navigationDestination(for: GameRoute.self) { route in
                 switch route {
-                case .game:
-                    GameView(path: $vm.path, vm: GameViewModel(isPracticeMode: false))
+                case .loading:
+                    if let player = vm.player {
+                        GameLoadingView(path: $vm.path, vm: GameLoadingViewModel(player: player))
+                    }
+                case .onlineGame:
+                    GameView(path: $vm.path, vm: GameViewModel(isPracticeMode: false, player: vm.player ?? fakePlayer, enemyPlayer: fakeEnemyPlayer))
+                case .offlineGame:
+                    GameView(path: $vm.path, vm: GameViewModel(isPracticeMode: false, player: vm.player ?? fakePlayer, enemyPlayer: fakeEnemyPlayer))
                 case .practice:
-                    GameView(path: $vm.path, vm: GameViewModel(isPracticeMode: true))
+                    GameView(path: $vm.path, vm: GameViewModel(isPracticeMode: true, player: vm.player ?? fakePlayer, enemyPlayer: fakeEnemyPlayer))
                 }
             }
             .background(
@@ -55,6 +61,8 @@ struct HomeView: View {
             .safeAreaInset(edge: .bottom) {
                 VStack {
                     playButton
+
+                    offlinePlayButton
 
                     practiceButton
                 }
@@ -88,11 +96,27 @@ struct HomeView: View {
 
     var playButton: some View {
         Button {
-            vm.path.append(GameRoute.game)
+            vm.path.append(GameRoute.loading)
         } label: {
             Image("playButton")
                 .frame(width: 200)
         }
+    }
+
+    var offlinePlayButton: some View {
+        Button {
+            vm.path.append(GameRoute.offlineGame)
+        } label: {
+            Text("Offline Play")
+                .padding(6)
+                .frame(maxWidth: .infinity)
+                .foregroundStyle(Color(uiColor: .systemBackground))
+                .font(.title)
+                .background(Color(uiColor: .label))
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 4)
     }
 
     var practiceButton: some View {
@@ -102,9 +126,9 @@ struct HomeView: View {
             Text("Practice")
                 .padding(6)
                 .frame(maxWidth: .infinity)
-                .foregroundStyle(Color(uiColor: .systemBackground))
+                .foregroundStyle(Color(uiColor: .label))
                 .font(.title)
-                .background(Color(uiColor: .label))
+                .background(Color(uiColor: .systemBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 16))
         }
         .padding(.horizontal)

--- a/iOS/FuFight-Old/FuFight/Home/HomeViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Home/HomeViewModel.swift
@@ -10,6 +10,7 @@ import FirebaseAuth
 
 @Observable
 class HomeViewModel: BaseAccountViewModel {
+    var player: Player?
     var isAccountVerified = false
     var path = NavigationPath()
 
@@ -34,6 +35,13 @@ private extension HomeViewModel {
                 if try await AccountNetworkManager.isAccountValid(userId: account.userId) {
                     LOGD("Account verified", from: HomeViewModel.self)
                     isAccountVerified = true
+                    self.player = Player(photoUrl: account.photoUrl ?? fakePhotoUrl,
+                                         username: Account.current?.displayName ?? "",
+                                         hp: defaultMaxHp,
+                                         maxHp: defaultMaxHp,
+                                         fighter: Fighter(type: .clara, isEnemy: false),
+                                         state: PlayerState(boostLevel: .none, hasSpeedBoost: false),
+                                         moves: Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses))
                     return
                 }
                 LOGE("Account is invalid \(account.displayName) with id \(account.userId)", from: HomeViewModel.self)


### PR DESCRIPTION
    - Create GameLoadingView with a cancel button to go back home, and will show GameView after 3 seconds
    - Edited `GameRoute` to add `loading` and `onlineGame`, and renamed `game` to `offlineGame`
    - Made `HomeView` the source of Game’s player
    - Made `GameLoadingView` the source of Game’s enemyPlayer
    - Show loading indicator when `GameLoadingView` and remove it right before transitioning to `GameView`