### PR TITLE
Commit 6: Upload and download both player’s attacks and defenses

### DIFF
--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLobby.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLobby.swift
@@ -7,24 +7,45 @@
 
 import FirebaseFirestore
 
-struct GameLobby: Codable {
+struct GameLobby {
     @DocumentID var lobbyId: String?
-    var userId: String
-    var username: String
-    var photoUrl: URL
-    var moves: Moves?
-    var fighterType: FighterType?
-    var enemyId: String?
-    var enemyUsername: String?
-    var enemyPhotoUrl: URL?
-    var enemyMoves: Moves?
-    var enemyFighterType: FighterType?
+    private(set) var userId: String?
+    private(set) var username: String?
+    private(set) var photoUrl: URL?
+    private(set) var moves: Moves?
+    private(set) var fighterType: FighterType?
+    private(set) var enemyId: String?
+    private(set) var enemyUsername: String?
+    private(set) var enemyPhotoUrl: URL?
+    private(set) var enemyMoves: Moves?
+    private(set) var enemyFighterType: FighterType?
 
     var isValid: Bool {
-        enemyId != nil && !userId.isEmpty
+        enemyId != nil && userId != nil
     }
 
-    //MARK: - Codable overrides
+    ///Lobby owner initializer
+    init(player: Player) {
+        self.userId = player.userId
+        self.username = player.username
+        self.photoUrl = player.photoUrl
+        self.moves = player.moves
+        self.fighterType = player.fighter.fighterType
+    }
+
+    ///Lobby joiner/enemy initializer
+    init(lobbyId: String, enemyPlayer: Player) {
+        self.lobbyId = lobbyId
+        self.enemyId = enemyPlayer.userId
+        self.enemyUsername = enemyPlayer.username
+        self.enemyPhotoUrl = enemyPlayer.photoUrl
+        self.enemyMoves = enemyPlayer.moves
+        self.enemyFighterType = enemyPlayer.fighter.fighterType
+    }
+}
+
+//MARK: - Decodable extension
+extension GameLobby: Codable {
     private enum CodingKeys : String, CodingKey {
         case userId = "userId"
         case username = "username"
@@ -40,19 +61,37 @@ struct GameLobby: Codable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(userId, forKey: .userId)
-        try container.encode(username, forKey: .username)
-        try container.encode(photoUrl, forKey: .photoUrl)
+        //This if let prevents writes to the database where the value is null
+        if let userId {
+            try container.encode(userId, forKey: .userId)
+        }
+        if let username {
+            try container.encode(username, forKey: .username)
+        }
+        if let photoUrl {
+            try container.encode(photoUrl, forKey: .photoUrl)
+        }
+        if let moves {
+            try container.encode(moves, forKey: .moves)
+        }
         if let fighterType {
             try container.encode(fighterType.rawValue, forKey: .fighterType)
         }
-        try container.encode(enemyId, forKey: .enemyId)
-        try container.encode(enemyUsername, forKey: .enemyUsername)
-        try container.encode(enemyPhotoUrl, forKey: .enemyPhotoUrl)
+        if let enemyId {
+            try container.encode(enemyId, forKey: .enemyId)
+        }
+        if let enemyUsername {
+            try container.encode(enemyUsername, forKey: .enemyUsername)
+        }
+        if let enemyPhotoUrl {
+            try container.encode(enemyPhotoUrl, forKey: .enemyPhotoUrl)
+        }
+        if let enemyMoves {
+            try container.encode(enemyMoves, forKey: .enemyMoves)
+        }
         if let enemyFighterType {
             try container.encode(enemyFighterType.rawValue, forKey: .enemyFighterType)
         }
-
     }
 
     init(from decoder: Decoder) throws {
@@ -60,12 +99,14 @@ struct GameLobby: Codable {
         self.userId = try values.decodeIfPresent(String.self, forKey: .userId)!
         self.username = try values.decodeIfPresent(String.self, forKey: .username)!
         self.photoUrl = try values.decodeIfPresent(URL.self, forKey: .photoUrl)!
+        self.moves = try values.decodeIfPresent(Moves.self, forKey: .moves)
         if let fighterId = try values.decodeIfPresent(String.self, forKey: .fighterType) {
             self.fighterType = FighterType(rawValue: fighterId)
         }
         self.enemyId = try values.decodeIfPresent(String.self, forKey: .enemyId)
         self.enemyUsername = try values.decodeIfPresent(String.self, forKey: .enemyUsername)
         self.enemyPhotoUrl = try values.decodeIfPresent(URL.self, forKey: .enemyPhotoUrl)
+        self.enemyMoves = try values.decodeIfPresent(Moves.self, forKey: .enemyMoves)
         if let enemyFighterId = try values.decodeIfPresent(String.self, forKey: .enemyFighterType) {
             self.enemyFighterType = FighterType(rawValue: enemyFighterId)
         }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameSceneView.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameSceneView.swift
@@ -98,7 +98,7 @@ private extension GameSceneView {
                 defensesView: DefensesView(
                     defenses: defaultAllDashDefenses,
                     playerType: .enemy) { move in
-                        guard let defense = Defense(move: move) else { return }
+                        guard let defense = Defense(moveId: move.id) else { return }
                         switch defense.position {
                         case .forward:
                             fighter.playAnimation(.idleStand)

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
@@ -77,7 +77,7 @@ class GameViewModel: BaseViewModel {
     func attackSelected(_ selectedMove: any MoveProtocol, isEnemy: Bool) {
         guard let enemyPlayer else { return }
         guard selectedMove.state != .cooldown,
-            let selectedAttack = Attack(move: selectedMove) else { return }
+              let selectedAttack = Attack(moveId: selectedMove.id) else { return }
         isEnemy ? enemyPlayer.moves.updateSelected(selectedAttack.position) : player.moves.updateSelected(selectedAttack.position)
         let attackResult = AttackResult.damage(20)
         if isPracticeMode,
@@ -92,7 +92,7 @@ class GameViewModel: BaseViewModel {
 
     func defenseSelected(_ selectedMove: any MoveProtocol, isEnemy: Bool) {
         guard selectedMove.state != .cooldown,
-              let selectedDefense = Defense(move: selectedMove) else { return }
+              let selectedDefense = Defense(moveId: selectedMove.id) else { return }
         isEnemy ? enemyPlayer?.moves.updateSelected(selectedDefense.position) : player.moves.updateSelected(selectedDefense.position)
     }
 

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Attack.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Attack.swift
@@ -42,7 +42,7 @@ protocol AttackProtocol {
     var canBoost: Bool { get }
 }
 
-struct Attack: MoveProtocol, AttackProtocol {
+struct Attack: MoveProtocol, AttackProtocol, AttackTypeProtocol {
     private let move: any AttackTypeProtocol
 
     //MARK: Move Protocol
@@ -73,8 +73,8 @@ struct Attack: MoveProtocol, AttackProtocol {
         self.move = attack
     }
 
-    init?(move: any Move) {
-        if let move = Punch(rawValue: move.id) {
+    init?(moveId: String) {
+        if let move = Punch(rawValue: moveId) {
             self.move = move
         } else {
             return nil
@@ -93,5 +93,23 @@ struct Attack: MoveProtocol, AttackProtocol {
     //MARK: - Other Public Methods
     mutating func setFireState(to newFireState: FireState) {
         self.fireState = newFireState
+    }
+}
+
+//MARK: - Decodable extension
+extension Attack: Codable {
+    private enum CodingKeys : String, CodingKey {
+        case move = "move"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(move.id, forKey: .move)
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let moveId = try values.decodeIfPresent(String.self, forKey: .move)!
+        self.move = Attack(moveId: moveId)!
     }
 }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Defense.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Defense.swift
@@ -27,7 +27,7 @@ protocol DefenseProtocol {
     var position: DefensePosition { get }
 }
 
-struct Defense: MoveProtocol, DefenseProtocol {
+struct Defense: MoveProtocol, DefenseProtocol, DefenseTypeProtocol {
     private let move: any DefenseTypeProtocol
 
     //MARK: Move Protocol Properties
@@ -53,8 +53,8 @@ struct Defense: MoveProtocol, DefenseProtocol {
         self.move = defense
     }
 
-    init?(move: any Move) {
-        if let move = Dash(rawValue: move.id) {
+    init?(moveId: String) {
+        if let move = Dash(rawValue: moveId) {
             self.move = move
         } else {
             return nil
@@ -71,4 +71,22 @@ struct Defense: MoveProtocol, DefenseProtocol {
     }
 
     //MARK: - Public Methods
+}
+
+//MARK: - Decodable extension
+extension Defense: Codable {
+    private enum CodingKeys : String, CodingKey {
+        case move = "move"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(move.id, forKey: .move)
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let moveId = try values.decodeIfPresent(String.self, forKey: .move)!
+        self.move = Defense(moveId: moveId)!
+    }
 }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Moves.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Moves.swift
@@ -230,3 +230,51 @@ private extension Moves {
         rightHardAttack.setFireState(to: .initial)
     }
 }
+
+//MARK: - Decodable extension
+extension Moves: Codable {
+    private enum CodingKeys : String, CodingKey {
+        case leftLightAttack = "leftLightAttack"
+        case rightLightAttack = "rightLightAttack"
+        case leftMediumAttack = "leftMediumAttack"
+        case rightMediumAttack = "rightMediumAttack"
+        case leftHardAttack = "leftHardAttack"
+        case rightHardAttack = "rightHardAttack"
+
+        case forwardDefense = "forwardDefense"
+        case leftDefense = "leftDefense"
+        case backwardDefense = "backwardDefense"
+        case rightDefense = "rightDefense"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(leftLightAttack, forKey: .leftLightAttack)
+        try container.encode(rightLightAttack, forKey: .rightLightAttack)
+        try container.encode(leftMediumAttack, forKey: .leftMediumAttack)
+        try container.encode(rightMediumAttack, forKey: .rightMediumAttack)
+        try container.encode(leftHardAttack, forKey: .leftHardAttack)
+        try container.encode(rightHardAttack, forKey: .rightHardAttack)
+        try container.encode(forwardDefense, forKey: .forwardDefense)
+        try container.encode(leftDefense, forKey: .leftDefense)
+        try container.encode(backwardDefense, forKey: .backwardDefense)
+        try container.encode(rightDefense, forKey: .rightDefense)
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let leftLightAttack = try values.decodeIfPresent(Attack.self, forKey: .leftLightAttack)!
+        let rightLightAttack = try values.decodeIfPresent(Attack.self, forKey: .rightLightAttack)!
+        let leftMediumAttack = try values.decodeIfPresent(Attack.self, forKey: .leftMediumAttack)!
+        let rightMediumAttack = try values.decodeIfPresent(Attack.self, forKey: .rightMediumAttack)!
+        let leftHardAttack = try values.decodeIfPresent(Attack.self, forKey: .leftHardAttack)!
+        let rightHardAttack = try values.decodeIfPresent(Attack.self, forKey: .rightHardAttack)!
+        let forwardDefense = try values.decodeIfPresent(Defense.self, forKey: .forwardDefense)!
+        let leftDefense = try values.decodeIfPresent(Defense.self, forKey: .leftDefense)!
+        let backwardDefense = try values.decodeIfPresent(Defense.self, forKey: .backwardDefense)!
+        let rightDefense = try values.decodeIfPresent(Defense.self, forKey: .rightDefense)!
+        let attacks: [Attack] = [leftLightAttack, rightLightAttack, leftMediumAttack, rightMediumAttack, leftHardAttack, rightHardAttack]
+        let defenses: [Defense] = [forwardDefense, leftDefense, backwardDefense, rightDefense]
+        self.init(attacks: attacks, defenses: defenses)
+    }
+}

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
@@ -69,10 +69,10 @@ class Player {
               let fighterType = lobby.fighterType,
               let enemyFighterType = lobby.enemyFighterType
         else { return nil }
-        self.photoUrl = !isLobbyOwner ? lobby.photoUrl : lobby.enemyPhotoUrl!
-        self.username = !isLobbyOwner ? lobby.username : lobby.enemyUsername!
-        self.userId = !isLobbyOwner ? lobby.userId : lobby.enemyId!
-        self.moves = (!isLobbyOwner ? lobby.moves : lobby.enemyMoves) ?? Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses)
+        self.photoUrl = !isLobbyOwner ? lobby.photoUrl! : lobby.enemyPhotoUrl!
+        self.username = !isLobbyOwner ? lobby.username! : lobby.enemyUsername!
+        self.userId = !isLobbyOwner ? lobby.userId! : lobby.enemyId!
+        self.moves = !isLobbyOwner ? lobby.moves! : lobby.enemyMoves!
         self.fighter = Fighter(type: !isLobbyOwner ? fighterType : enemyFighterType, isEnemy: true)
         self.hp = defaultMaxHp
         self.maxHp = defaultMaxHp


### PR DESCRIPTION
    - Made `GameLobby`, `Moves`, `Attack`, and `Defense` conform to `Codable` in order to easily decode and encode response from the database. Safer than using dictionary
    - Updated `GameLobby` to not set null data to the database
    - Create `Attack` and `Defense` from their Move.id instead
    - Made createLobby and joinLobby take a GameLobby instead