### PR TITLE
Commit 10: Make the lobby owner create a Game for both players

### DIFF
--- a/iOS/FuFight-Old/FuFight/Account/Account.swift
+++ b/iOS/FuFight-Old/FuFight/Account/Account.swift
@@ -76,10 +76,14 @@ class Account: ObservableObject, Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(username, forKey: .username)
-        try container.encode(photoUrl, forKey: .photoUrl)
+        if let photoUrl {
+            try container.encode(photoUrl, forKey: .photoUrl)
+        }
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(email, forKey: .email)
-        try container.encode(phoneNumber, forKey: .phoneNumber)
+        if let phoneNumber {
+            try container.encode(phoneNumber, forKey: .phoneNumber)
+        }
         try container.encode(status.rawValue, forKey: .status)
     }
 

--- a/iOS/FuFight-Old/FuFight/Account/AccountView.swift
+++ b/iOS/FuFight-Old/FuFight/Account/AccountView.swift
@@ -65,6 +65,7 @@ struct AccountView: View {
         .onTapGesture {
             hideKeyboard()
         }
+        .toolbar(.hidden, for: .tabBar)
     }
 
     var editSaveButton: some View {

--- a/iOS/FuFight-Old/FuFight/Account/UpdatePassword/UpdatePasswordView.swift
+++ b/iOS/FuFight-Old/FuFight/Account/UpdatePassword/UpdatePasswordView.swift
@@ -55,6 +55,7 @@ struct UpdatePasswordView: View {
             backgroundImage
                 .padding(.trailing, 800)
         )
+        .toolbar(.hidden, for: .tabBar)
     }
 
     var currentPasswordField: some View {

--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/FetchedPlayer.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/FetchedPlayer.swift
@@ -1,0 +1,87 @@
+//
+//  FetchedPlayer.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 5/20/24.
+//
+
+import FirebaseFirestore
+
+struct FetchedGame {
+    private(set) var player: FetchedPlayer
+    private(set) var enemyPlayer: FetchedPlayer
+}
+
+//MARK: - Codable extension
+extension FetchedGame: Codable {
+    private enum CodingKeys : String, CodingKey {
+        case player = "userPlayer"
+        case enemyPlayer = "enemyPlayer"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(player, forKey: .player)
+        try container.encode(enemyPlayer, forKey: .enemyPlayer)
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.player = try values.decodeIfPresent(FetchedPlayer.self, forKey: .player)!
+        self.enemyPlayer = try values.decodeIfPresent(FetchedPlayer.self, forKey: .enemyPlayer)!
+    }
+}
+
+struct FetchedPlayer {
+    private(set) var userId: String
+    private(set) var username: String
+    private(set) var photoUrl: URL
+    private(set) var moves: Moves
+    private(set) var fighterType: FighterType
+
+    init(_ player: Player) {
+        self.userId = player.userId
+        self.username = player.username
+        self.photoUrl = player.photoUrl!
+        self.moves = player.moves
+        self.fighterType = player.fighter.fighterType
+    }
+
+//    init?(fetchedPlayerDic: [String: Any]) {
+//        guard let userId = fetchedPlayerDic[kUSERID] as? String,
+//              let username = fetchedPlayerDic[kUSERNAME] as? String,
+//              let urlString = fetchedPlayerDic[kPHOTOURL] as? String,
+//              let fighterTypeId = fetchedPlayerDic[kUSERFIGHTERTYPE] as? String,
+//    }
+}
+
+//MARK: - Codable extension
+extension FetchedPlayer: Codable {
+    private enum CodingKeys : String, CodingKey {
+        case userId = "userId"
+        case username = "username"
+        case photoUrl = "photoUrl"
+        case moves = "moves"
+        case fighterType = "fighterType"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        //This if let prevents writes to the database where the value is null
+        try container.encode(userId, forKey: .userId)
+        try container.encode(username, forKey: .username)
+        try container.encode(photoUrl, forKey: .photoUrl)
+        try container.encode(moves, forKey: .moves)
+        try container.encode(fighterType.rawValue, forKey: .fighterType)
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.userId = try values.decodeIfPresent(String.self, forKey: .userId)!
+        self.username = try values.decodeIfPresent(String.self, forKey: .username)!
+        self.photoUrl = try values.decodeIfPresent(URL.self, forKey: .photoUrl)!
+        self.moves = try values.decodeIfPresent(Moves.self, forKey: .moves)!
+        let fighterId = try values.decodeIfPresent(String.self, forKey: .fighterType)!
+        self.fighterType = FighterType(rawValue: fighterId)!
+    }
+}

--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLobby.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLobby.swift
@@ -9,106 +9,54 @@ import FirebaseFirestore
 
 struct GameLobby {
     @DocumentID var lobbyId: String?
-    private(set) var userId: String?
-    private(set) var username: String?
-    private(set) var photoUrl: URL?
-    private(set) var moves: Moves?
-    private(set) var fighterType: FighterType?
-    private(set) var enemyId: String?
-    private(set) var enemyUsername: String?
-    private(set) var enemyPhotoUrl: URL?
-    private(set) var enemyMoves: Moves?
-    private(set) var enemyFighterType: FighterType?
+    private(set) var player: FetchedPlayer?
+    private(set) var challengers: [FetchedPlayer] = []
+    private(set) var isSearching: Bool = true
 
     var isValid: Bool {
-        enemyId != nil && userId != nil
+        player != nil && challengers.first != nil
     }
 
     ///Lobby owner initializer
     init(player: Player) {
-        self.userId = player.userId
-        self.username = player.username
-        self.photoUrl = player.photoUrl
-        self.moves = player.moves
-        self.fighterType = player.fighter.fighterType
+        self.player = FetchedPlayer(player)
     }
 
     ///Lobby joiner/enemy initializer
     init(lobbyId: String, enemyPlayer: Player) {
         self.lobbyId = lobbyId
-        self.enemyId = enemyPlayer.userId
-        self.enemyUsername = enemyPlayer.username
-        self.enemyPhotoUrl = enemyPlayer.photoUrl
-        self.enemyMoves = enemyPlayer.moves
-        self.enemyFighterType = enemyPlayer.fighter.fighterType
+        challengers.append(FetchedPlayer(enemyPlayer))
+    }
+
+    mutating func leave(userId: String) {
+        for (index, challenger) in challengers.enumerated() where challenger.userId == userId {
+            challengers.remove(at: index)
+        }
     }
 }
 
-//MARK: - Decodable extension
+//MARK: - Codable extension
 extension GameLobby: Codable {
     private enum CodingKeys : String, CodingKey {
-        case userId = "userId"
-        case username = "username"
-        case photoUrl = "photoUrl"
-        case moves = "moves"
-        case fighterType = "fighterType"
-        case enemyId = "enemyId"
-        case enemyUsername = "enemyUsername"
-        case enemyPhotoUrl = "enemyPhotoUrl"
-        case enemyMoves = "enemyMoves"
-        case enemyFighterType = "enemyFighterType"
+        case player = "player"
+        case challengers = "challengers"
+        case isSearching = "isSearching"
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         //This if let prevents writes to the database where the value is null
-        if let userId {
-            try container.encode(userId, forKey: .userId)
+        if let player {
+            try container.encode(player, forKey: .player)
         }
-        if let username {
-            try container.encode(username, forKey: .username)
-        }
-        if let photoUrl {
-            try container.encode(photoUrl, forKey: .photoUrl)
-        }
-        if let moves {
-            try container.encode(moves, forKey: .moves)
-        }
-        if let fighterType {
-            try container.encode(fighterType.rawValue, forKey: .fighterType)
-        }
-        if let enemyId {
-            try container.encode(enemyId, forKey: .enemyId)
-        }
-        if let enemyUsername {
-            try container.encode(enemyUsername, forKey: .enemyUsername)
-        }
-        if let enemyPhotoUrl {
-            try container.encode(enemyPhotoUrl, forKey: .enemyPhotoUrl)
-        }
-        if let enemyMoves {
-            try container.encode(enemyMoves, forKey: .enemyMoves)
-        }
-        if let enemyFighterType {
-            try container.encode(enemyFighterType.rawValue, forKey: .enemyFighterType)
-        }
+        try container.encode(challengers, forKey: .challengers)
+        try container.encode(isSearching, forKey: .isSearching)
     }
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        self.userId = try values.decodeIfPresent(String.self, forKey: .userId)!
-        self.username = try values.decodeIfPresent(String.self, forKey: .username)!
-        self.photoUrl = try values.decodeIfPresent(URL.self, forKey: .photoUrl)!
-        self.moves = try values.decodeIfPresent(Moves.self, forKey: .moves)
-        if let fighterId = try values.decodeIfPresent(String.self, forKey: .fighterType) {
-            self.fighterType = FighterType(rawValue: fighterId)
-        }
-        self.enemyId = try values.decodeIfPresent(String.self, forKey: .enemyId)
-        self.enemyUsername = try values.decodeIfPresent(String.self, forKey: .enemyUsername)
-        self.enemyPhotoUrl = try values.decodeIfPresent(URL.self, forKey: .enemyPhotoUrl)
-        self.enemyMoves = try values.decodeIfPresent(Moves.self, forKey: .enemyMoves)
-        if let enemyFighterId = try values.decodeIfPresent(String.self, forKey: .enemyFighterType) {
-            self.enemyFighterType = FighterType(rawValue: enemyFighterId)
-        }
+        self.player = try values.decodeIfPresent(FetchedPlayer.self, forKey: .player)
+        self.isSearching = try values.decodeIfPresent(Bool.self, forKey: .isSearching) ?? false
+        self.challengers = try values.decodeIfPresent(Array<FetchedPlayer>.self, forKey: .challengers) ?? []
     }
 }

--- a/iOS/FuFight-Old/FuFight/Game/GameNetworkManager.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameNetworkManager.swift
@@ -14,13 +14,13 @@ class GameNetworkManager {
     private init() {}
 }
 
-//MARK: - Lobby Extension
-extension GameNetworkManager { 
+//MARK: - Lobby methods
+extension GameNetworkManager {
     ///Fetch an available lobby if there's any available. Return avaialble lobbyIds
     static func findAvailableLobbies(userId: String) async throws -> [String] {
-        let nonUserLobbyFilter: Filter = .whereField(kUSERID, isNotEqualTo: userId)
+        let nonUserLobbyFilter: Filter = .whereField("player.\(kUSERID)", isNotEqualTo: userId)
         do {
-            let availableLobbies = try await lobbiesDb.whereFilter(nonUserLobbyFilter).getDocuments()
+            let availableLobbies = try await lobbiesDb.whereFilter(nonUserLobbyFilter).limit(to: 3).getDocuments()
             let lobbyIds = availableLobbies.documents.compactMap { $0.documentID }
             LOGD("Total lobbies found: \(lobbyIds.count)")
             return lobbyIds
@@ -30,14 +30,14 @@ extension GameNetworkManager {
     }
 
     ///For lobby owner to create a new or rejoin an existing lobby
-    static func createLobby(lobby: GameLobby) async throws -> GameLobby {
+    static func createOrRejoinLobby(lobby: GameLobby) async throws -> GameLobby {
         var updatedLobby = lobby
         do {
-            let userId = lobby.userId!
+            let userId = lobby.player!.userId
             //Check if user already has a lobby created
             let lobbyDocuments = try await lobbiesDb.whereField(kUSERID, isEqualTo: userId).getDocuments()
             if lobbyDocuments.isEmpty {
-                let lobbyDocument = lobbiesDb.document()
+                let lobbyDocument = lobbiesDb.document(userId)
                 try lobbyDocument.setData(from: lobby)
                 LOGD("Current lobby created with id: \(lobbyDocument.documentID)")
                 updatedLobby.lobbyId = lobbyDocument.documentID
@@ -64,9 +64,13 @@ extension GameNetworkManager {
         }
     }
 
-    ///For enemy joining a lobby
+    ///For enemy joining a lobby as one of the challengers
     static func joinLobby(lobby: GameLobby) async throws {
         do {
+            let enemyPlayer = lobby.challengers.first!
+            let enemyDic: [String: Any] = [
+                kCHALLENGERS: FieldValue.arrayUnion([try enemyPlayer.asDictionary()]),
+            ]
             try lobbiesDb.document(lobby.lobbyId!).setData(from: lobby, merge: true)
             LOGD("User joined someone's lobby as enemy with lobby id: \(lobby.lobbyId!)")
         } catch {
@@ -75,17 +79,37 @@ extension GameNetworkManager {
     }
 
     ///For enemy to leave a lobby
-    static func leaveLobby(lobbyId: String) async throws {
+    static func leaveLobby(_ lobby: GameLobby?) async throws {
+        guard let lobby, let lobbyId = lobby.lobbyId else { return }
         do {
-            let enemyDic: [String: Any] = [
-                kENEMYID: FieldValue.delete(),
-                kENEMYUSERNAME: FieldValue.delete(),
-                kENEMYPHOTOURL: FieldValue.delete(),
-                kENEMYFIGHTERTYPE: FieldValue.delete(),
-                kENEMYMOVES: FieldValue.delete(),
-            ]
-            try await lobbiesDb.document(lobbyId).setData(enemyDic, merge: true)
+            try lobbiesDb.document(lobbyId).setData(from: lobby, merge: true)
             LOGD("User left lobby as enemy with lobby id: \(lobbyId)")
+        } catch {
+            throw error
+        }
+    }
+}
+
+//MARK: - Game methods
+extension GameNetworkManager {
+    static func createGameFromLobby(_ lobby: GameLobby?) async throws {
+        guard let lobby, let player = lobby.player, let enemyPlayer = lobby.challengers.first else { return }
+        do {
+            let gameDic: [String: Any] = [
+                kUSERPLAYER: try player.asDictionary(),
+                kENEMYPLAYER: try enemyPlayer.asDictionary(),
+            ]
+            try await gamesDb.document(player.userId).setData(gameDic)
+            LOGD("Lobby owner \(player.username) created a Game document against \(enemyPlayer.username) lobby id: \(lobby.lobbyId ?? "")")
+        } catch {
+            throw error
+        }
+    }
+
+    static func deleteGame(_ userId: String) async throws {
+        do {
+            try await gamesDb.document(userId).delete()
+            LOGD("Lobby creator's game is deleted at: \(userId)")
         } catch {
             throw error
         }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameView.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameView.swift
@@ -62,6 +62,7 @@ struct GameView: View {
         .onReceive(vm.timer) { time in
             vm.decrementTimeByOneSecond()
         }
+        .toolbar(.hidden, for: .tabBar)
     }
 
     var timerView: some View {

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
@@ -23,18 +23,17 @@ enum GameState {
     }
 }
 
-@Observable
 class GameViewModel: BaseViewModel {
-    var state: GameState
-    var player: Player
-    var enemyPlayer: Player?
+    @Published var state: GameState
+    @Published var player: Player
+    @Published var enemyPlayer: Player?
     let isPracticeMode: Bool
 
     let didExitGame = PassthroughSubject<GameViewModel, Never>()
     var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-    var timeRemaining = defaultMaxTime
+    @Published var timeRemaining = defaultMaxTime
     var isCountingDown: Bool = false
-    var isGamePaused: Bool = false
+    @Published var isGamePaused: Bool = false
     var isDefenderAlive = true
     var secondAttackerDamageDealtReduction: CGFloat = 0
     var secondAttackerDelay: CGFloat = 0

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
@@ -66,14 +66,30 @@ class Player {
     ///Creates an enemy player from the lobby
     init?(lobby: GameLobby?, isLobbyOwner: Bool) {
         guard let lobby,
-              let fighterType = lobby.fighterType,
-              let enemyFighterType = lobby.enemyFighterType
+              let player = lobby.player,
+              let enemyPlayer = lobby.challengers.first
         else { return nil }
-        self.photoUrl = !isLobbyOwner ? lobby.photoUrl! : lobby.enemyPhotoUrl!
-        self.username = !isLobbyOwner ? lobby.username! : lobby.enemyUsername!
-        self.userId = !isLobbyOwner ? lobby.userId! : lobby.enemyId!
-        self.moves = !isLobbyOwner ? lobby.moves! : lobby.enemyMoves!
-        self.fighter = Fighter(type: !isLobbyOwner ? fighterType : enemyFighterType, isEnemy: true)
+        self.photoUrl = !isLobbyOwner ? player.photoUrl : enemyPlayer.photoUrl
+        self.username = !isLobbyOwner ? player.username : enemyPlayer.username
+        self.userId = !isLobbyOwner ? player.userId : enemyPlayer.userId
+        self.moves = !isLobbyOwner ? player.moves : enemyPlayer.moves
+        self.fighter = Fighter(type: !isLobbyOwner ? player.fighterType : enemyPlayer.fighterType, isEnemy: true)
+        self.hp = defaultMaxHp
+        self.maxHp = defaultMaxHp
+        self.rounds = []
+        self.speed = 0
+        self.isEnemy = true
+        //TODO: hasSpeedBoost should not be false
+        self.state = .init(boostLevel: .none, hasSpeedBoost: false)
+    }
+
+    ///Lobby owner's initializer
+    init(fetchedPlayer: FetchedPlayer) {
+        self.photoUrl = fetchedPlayer.photoUrl
+        self.username = fetchedPlayer.username
+        self.userId = fetchedPlayer.userId
+        self.moves = fetchedPlayer.moves
+        self.fighter = Fighter(type: fetchedPlayer.fighterType, isEnemy: true)
         self.hp = defaultMaxHp
         self.maxHp = defaultMaxHp
         self.rounds = []

--- a/iOS/FuFight-Old/FuFight/Helpers/Constants/ConstantKeys.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/Constants/ConstantKeys.swift
@@ -9,17 +9,22 @@ import Foundation
 
 //Account Keys
 public let kCURRENTACCOUNT: String = "currentAccount"
+
+public let kUSERPLAYER: String = "userPlayer"
 public let kUSERID: String = "userId"
 public let kUSERNAME: String = "username"
 public let kPHOTOURL: String = "photoUrl"
 public let kUSERMOVES: String = "moves"
 public let kUSERFIGHTERTYPE: String = "fighterType"
 
+public let kENEMYPLAYER: String = "enemyPlayer"
 public let kENEMYID: String = "enemyId"
 public let kENEMYUSERNAME: String = "enemyUsername"
 public let kENEMYPHOTOURL: String = "enemyPhotoUrl"
 public let kENEMYMOVES: String = "enemyMoves"
 public let kENEMYFIGHTERTYPE: String = "enemyFighterType"
+
+public let kCHALLENGERS: String = "challengers"
 
 public let kEMAIL: String = "email"
 public let kCREATEDAT: String = "createdAt"

--- a/iOS/FuFight-Old/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/Constants/Constants.swift
@@ -35,7 +35,7 @@ let accountPhotoCompressionQuality: Double = 0.3
 let smallerHorizontalPadding: CGFloat = 18
 let horizontalPadding: CGFloat = 36
 let accountImagePickerHeight: CGFloat = 160
-let defaultMaxTime: Int = 8
+let defaultMaxTime: Int = 5
 let defaultMaxHp: CGFloat = 100
 let defaultEnemyHp: CGFloat = 100
 

--- a/iOS/FuFight-Old/FuFight/Helpers/Extensions/Encodable+Extensions.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/Extensions/Encodable+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  Encodable+Extensions.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 5/20/24.
+//
+
+import Foundation
+
+extension Encodable {
+    func asDictionary() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(self)
+        guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
+            throw NSError()
+        }
+        return dictionary
+    }
+}

--- a/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
+++ b/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
@@ -43,7 +43,7 @@ class HomeRouter: ObservableObject {
         UITabBar.appearance().backgroundColor = UIColor.clear
         UITabBar.appearance().backgroundImage = UIImage()
         //Change TabItem (text + icon) color
-        UITabBar.appearance().unselectedItemTintColor = UIColor.systemGray2
+        UITabBar.appearance().unselectedItemTintColor = UIColor.darkGray
     }
 
     //MARK: - Home Methods


### PR DESCRIPTION
    - Hide tabBar on GameView and AccountView
    - Created `FetchedPlayer` to represent both user and enemyPlayer in `GameLobby`
    - Added a way to create a game
    - Added a way to delete the `Lobby` and the `Game` in database when app is dismissed
    - Made `GameViewModel` not have `@Observable` anymore to be consistent with all of the ViewModels
    - Made Account and other `Codable` objects not encode or decode a null properties
    - Added a way for lobby owner to create a game from lobby and to delete the game document
    - Created `FetchedGame` for lobby joiner to fetch Game data
    - Lobby joiner will now wait for Game to be added