### PR TITLE
Commit 19: Create and fetch room when authenticating

### DIFF
--- a/iOS/FuFight-Old/FuFight/Account/Account.swift
+++ b/iOS/FuFight-Old/FuFight/Account/Account.swift
@@ -18,7 +18,7 @@ class Account: ObservableObject, Codable {
     @Published private(set) var phoneNumber: String?
     @Published private(set) var createdAt: Date?
     @Published var photoUrl: URL?
-    @Published var status: Account.Status = .unfinished
+    @Published var status: Account.Status = .logOut
 
     var userId: String {
         return id!

--- a/iOS/FuFight-Old/FuFight/Account/AccountNetworkManager.swift
+++ b/iOS/FuFight-Old/FuFight/Account/AccountNetworkManager.swift
@@ -191,7 +191,7 @@ extension AccountNetworkManager {
     }
 
     ///Set username to the database into Accounts collections
-    static func setUsername(_ username: String, userId: String, email: String? = nil) async throws {
+    static func updateUsername(to username: String, for userId: String) async throws {
         let username = username.trimmed
         guard !userId.isEmpty,
               !username.isEmpty else { return }

--- a/iOS/FuFight-Old/FuFight/Account/AccountViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Account/AccountViewModel.swift
@@ -181,7 +181,7 @@ private extension AccountViewModel {
             if didChangeUsername || newPhotoUrl != nil {
                 if didChangeUsername {
                     updateLoadingMessage(to: Str.updatingUsername)
-                    try await AccountNetworkManager.setUsername(username, userId: account.userId, email: account.email)
+                    try await AccountNetworkManager.updateUsername(to: username, for: account.userId)
                     if Defaults.isSavingEmailAndPassword {
                         Defaults.savedEmailOrUsername = username
                     }

--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/FetchedPlayer.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/FetchedPlayer.swift
@@ -12,18 +12,8 @@ class FetchedPlayer: PlayerProtocol {
     private(set) var userId: String
     private(set) var username: String
     private(set) var photoUrl: URL
-    private(set) var isEnemy: Bool
     var fighterType: FighterType
     var moves: Moves
-
-    init(userId: String, username: String, photoUrl: URL, isEnemy: Bool, fighterType: FighterType, moves: Moves) {
-        self.userId = userId
-        self.username = username
-        self.photoUrl = photoUrl
-        self.isEnemy = isEnemy
-        self.fighterType = fighterType
-        self.moves = moves
-    }
 
     init(_ player: Player) {
         self.userId = player.userId
@@ -31,7 +21,6 @@ class FetchedPlayer: PlayerProtocol {
         self.photoUrl = player.photoUrl
         self.moves = player.moves
         self.fighterType = player.fighter.fighterType
-        self.isEnemy = player.isEnemy
     }
 
     ///Creates an enemy player from the room
@@ -45,7 +34,6 @@ class FetchedPlayer: PlayerProtocol {
         self.userId = !isRoomOwner ? player.userId : enemyPlayer.userId
         self.moves = !isRoomOwner ? player.moves : enemyPlayer.moves
         self.fighterType = !isRoomOwner ? player.fighterType : enemyPlayer.fighterType
-        self.isEnemy = true
     }
 
     ///Default value/initializer for FetchedPlayer from current logged in account
@@ -55,7 +43,6 @@ class FetchedPlayer: PlayerProtocol {
         self.photoUrl = account.photoUrl!
         self.fighterType = .samuel
         self.moves = Moves(attacks: Punch.allCases.compactMap { Attack($0) }, defenses: Dash.allCases.compactMap { Defense($0) })
-        self.isEnemy = false
     }
 
     required init(from decoder: Decoder) throws {
@@ -68,7 +55,6 @@ class FetchedPlayer: PlayerProtocol {
         let fighterId = try values.decodeIfPresent(String.self, forKey: .fighterType)!
         let fighterType = FighterType(rawValue: fighterId)!
         self.fighterType = fighterType
-        self.isEnemy = try values.decodeIfPresent(Bool.self, forKey: .isEnemy)!
     }
 }
 
@@ -80,7 +66,6 @@ extension FetchedPlayer: Codable {
         case photoUrl = "photoUrl"
         case moves = "moves"
         case fighterType = "fighterType"
-        case isEnemy = "isEnemy"
     }
 
     func encode(to encoder: Encoder) throws {
@@ -91,6 +76,5 @@ extension FetchedPlayer: Codable {
         try container.encode(photoUrl, forKey: .photoUrl)
         try container.encode(moves, forKey: .moves)
         try container.encode(fighterType.rawValue, forKey: .fighterType)
-        try container.encode(isEnemy, forKey: .isEnemy)
     }
 }

--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLoadingView.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLoadingView.swift
@@ -45,7 +45,6 @@ struct GameLoadingView: View {
 
     var cancelButton: some View {
         Button {
-            vm.deleteCurrentRoom()
             vm.didCancel.send(vm)
         } label: {
             Text("Cancel")

--- a/iOS/FuFight-Old/FuFight/Game/GameNetworkManager.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameNetworkManager.swift
@@ -25,7 +25,7 @@ extension GameNetworkManager {
                 kENEMYPLAYER: try enemyPlayer.asDictionary(),
             ]
             try await gamesDb.document(player.userId).setData(gameDic)
-            LOGD("Room owner \(player.username) created a Game document against \(enemyPlayer.username)")
+            LOGD("createGameFromRoom() Room owner \(player.username) created a Game document against \(enemyPlayer.username)")
         } catch {
             throw error
         }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameView.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameView.swift
@@ -113,7 +113,6 @@ private extension GameView {
         Task {
             do {
                 TODO("todo only delete room and game if player is owner")
-                try await RoomNetworkManager.deleteCurrentRoom(roomId: vm.player.userId)
                 try await GameNetworkManager.deleteGame(vm.player.userId)
             }
         }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
@@ -140,7 +140,7 @@ private extension GameViewModel {
     func createNewRound() {
         player.prepareForNewRound()
         print("\n\n=================================== Round \(self.player.rounds.count) ============================================")
-        enemyPlayer?.prepareForNewRound()
+        enemyPlayer!.prepareForNewRound()
         timeRemaining = defaultMaxTime
         secondAttackerDelay = 0
         secondAttackerDamageDealtReduction = 0

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Moves.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Moves.swift
@@ -176,8 +176,8 @@ extension Moves: Codable {
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        let attacks = try values.decodeIfPresent([Attack].self, forKey: .attacks)!
-        let defenses = try values.decodeIfPresent([Defense].self, forKey: .defenses)!
+        let attacks = try values.decodeIfPresent(Array<Attack>.self, forKey: .attacks)!
+        let defenses = try values.decodeIfPresent(Array<Defense>.self, forKey: .defenses)!
         self.init(attacks: attacks, defenses: defenses)
     }
 }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
@@ -71,17 +71,17 @@ class Player: PlayerProtocol {
     }
 
     ///Room owner's initializer
-    init(_ fetchedPlayer: FetchedPlayer) {
+    init(fetchedPlayer: FetchedPlayer, isEnemy: Bool) {
         self.photoUrl = fetchedPlayer.photoUrl
         self.username = fetchedPlayer.username
         self.userId = fetchedPlayer.userId
         self.moves = fetchedPlayer.moves
-        self.fighter = Fighter(type: fetchedPlayer.fighterType, isEnemy: fetchedPlayer.isEnemy)
+        self.fighter = Fighter(type: fetchedPlayer.fighterType, isEnemy: isEnemy)
         self.hp = defaultMaxHp
         self.maxHp = defaultMaxHp
         self.rounds = []
         self.speed = 0
-        self.isEnemy = fetchedPlayer.isEnemy
+        self.isEnemy = isEnemy
         //TODO: hasSpeedBoost should not be false
         self.state = .init(boostLevel: .none, hasSpeedBoost: false)
     }

--- a/iOS/FuFight-Old/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
@@ -28,6 +28,7 @@ enum MainErrorType {
     case noEmailFromUsername
     case reauthenticatingUser
     case noOpponentFound
+    case updatingAccountOrRoom
 
     var title: String {
         switch self {
@@ -71,6 +72,8 @@ enum MainErrorType {
             "Could not fetch email from username provided"
         case .noOpponentFound:
             "Error finding opponent"
+        case .updatingAccountOrRoom:
+            "Error updating account's data"
         }
     }
 }

--- a/iOS/FuFight-Old/FuFight/Helpers/CustomViews/UnderlinedTextField.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/CustomViews/UnderlinedTextField.swift
@@ -191,7 +191,7 @@ struct UnderlinedTextField: View {
                 .focused($isFocused)
                 .textContentType(type.contentType)
                 .submitLabel(type.submitLabel)
-
+                
                 accessories
             }
         }

--- a/iOS/FuFight/FuFight/App/ContentView.swift
+++ b/iOS/FuFight/FuFight/App/ContentView.swift
@@ -139,7 +139,6 @@ private extension ContentView {
         case .background:
             Task {
                 if let account = Account.current {
-                    try await RoomNetworkManager.deleteCurrentRoom(roomId: account.userId)
                     try await GameNetworkManager.deleteGame(account.userId)
                     //TODO: Maybe save game locally in order to rejoin
                     LOGD("App is terminated, room and game is deleted")

--- a/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
+++ b/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
@@ -71,7 +71,7 @@ class HomeRouter: ObservableObject {
     }
 
     func transitionTo(route: GameRoute, vm: HomeViewModel) {
-        let player = Player(vm.player!)
+        let player = Player(fetchedPlayer: vm.player!, isEnemy: true)
         switch route {
         case .onlineGame:
             //show loading and let loading handle transition to online game
@@ -120,7 +120,7 @@ class HomeRouter: ObservableObject {
 
     func didCompleteLoading(vm: GameLoadingViewModel) {
         if let enemyPlayer = vm.enemyPlayer {
-            navigationPath.append(.game(vm: makeGameViewModel(isPracticeMode: false, player: Player(vm.player), enemyPlayer: Player(enemyPlayer))))
+            navigationPath.append(.game(vm: makeGameViewModel(isPracticeMode: false, player: Player(fetchedPlayer: vm.player, isEnemy: true), enemyPlayer: Player(fetchedPlayer: enemyPlayer, isEnemy: false))))
         }
     }
 

--- a/iOS/FuFight/FuFight/Room/Room.swift
+++ b/iOS/FuFight/FuFight/Room/Room.swift
@@ -14,7 +14,7 @@ class Room: Codable {
     ///Player that owns the room
     private(set) var player: FetchedPlayer?
     private(set) var challengers: [FetchedPlayer] = []
-    private(set) var isSearching: Bool = true
+    private(set) var isSearching: Bool = false
 
     var isValid: Bool {
         player != nil && challengers.first != nil
@@ -26,9 +26,9 @@ class Room: Codable {
     }
 
     ///Room owner initializer
-    init(player: FetchedPlayer) {
-        self.documentId = player.userId
-        self.player = player
+    init(ownerPlayer: FetchedPlayer) {
+        self.documentId = ownerPlayer.userId
+        self.player = ownerPlayer
     }
 
     ///Room joiner/enemy initializer

--- a/iOS/FuFight/FuFight/Room/RoomViewModel.swift
+++ b/iOS/FuFight/FuFight/Room/RoomViewModel.swift
@@ -26,6 +26,9 @@ final class RoomViewModel: BaseAccountViewModel {
         guard let currentRoom = RoomManager.getCurrent() else { return }
         currentRoom.updatePlayer(player: tempPlayer)
         RoomManager.saveCurrent(currentRoom)
+        Task {
+            try await RoomNetworkManager.createRoom(currentRoom)
+        }
         player = tempPlayer
     }
 


### PR DESCRIPTION
    - Add a way to `createRoom()` when `Account` is created during `finishOnboarding()` and `fetchRoom()` when logging in
    - Refactored authentication flow to also fetch and create room
        - Removed unnecessary update on username
    - Fix issue where `Room` joiner’s `isEnemy` is incorrect
        - Fix playerView flipped the wrong way for joiner