### PR TITLE
- Commit 20: Fix Loading with room changes (5/29 - 5/31)

### DIFF
--- a/iOS/FuFight-Old/FuFight/Account/Account.swift
+++ b/iOS/FuFight-Old/FuFight/Account/Account.swift
@@ -18,7 +18,7 @@ class Account: ObservableObject, Codable {
     @Published private(set) var phoneNumber: String?
     @Published private(set) var createdAt: Date?
     @Published var photoUrl: URL?
-    @Published var status: Account.Status = .logOut
+    @Published var status: Account.Status = .loggedOut
 
     var userId: String {
         return id!
@@ -143,9 +143,9 @@ class Account: ObservableObject, Codable {
 //MARK: - Custom Account Classes
 extension Account {
     enum Status: String {
-        case online
+        case loggedIn
         ///When account is created but unfinished
         case unfinished
-        case logOut
+        case loggedOut
     }
 }

--- a/iOS/FuFight-Old/FuFight/Account/AccountViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Account/AccountViewModel.swift
@@ -72,7 +72,7 @@ final class AccountViewModel: BaseAccountViewModel {
                 AccountManager.deleteCurrent()
                 updateError(nil)
                 account.reset()
-                account.status = .logOut
+                account.status = .loggedOut
                 if Defaults.isSavingEmailAndPassword {
                     Defaults.savedEmailOrUsername = ""
                     Defaults.savedPassword = ""
@@ -136,7 +136,7 @@ final class AccountViewModel: BaseAccountViewModel {
 //MARK: - Private Methods
 private extension AccountViewModel {
     func transitionToAuthenticationView() {
-        account.status = .logOut
+        account.status = .loggedOut
         AccountManager.saveCurrent(account)
     }
 

--- a/iOS/FuFight-Old/FuFight/Authentication/AuthenticationViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Authentication/AuthenticationViewModel.swift
@@ -268,7 +268,7 @@ private extension AuthenticationViewModel {
     func saveAccountAndRoom(isLogIn: Bool) {
         //account needed to be duplicated in order to update the account's status without transitioning to HomeView
         let onlineAccount = account
-        onlineAccount.status = .online
+        onlineAccount.status = .loggedIn
         Task {
             do {
                 try await AccountNetworkManager.setData(account: onlineAccount)
@@ -290,7 +290,7 @@ private extension AuthenticationViewModel {
     }
 
     func transitionToHomeView() {
-        account.status = .online
+        account.status = .loggedIn
     }
 
     func resetFields() {

--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLoadingView.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLoadingView.swift
@@ -45,7 +45,7 @@ struct GameLoadingView: View {
 
     var cancelButton: some View {
         Button {
-            vm.didCancel.send(vm)
+            vm.cancelButtonTapped()
         } label: {
             Text("Cancel")
                 .padding(6)

--- a/iOS/FuFight-Old/FuFight/Helpers/Constants/ConstantKeys.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/Constants/ConstantKeys.swift
@@ -27,6 +27,7 @@ public let kENEMYFIGHTERTYPE: String = "enemyFighterType"
 
 public let kCHALLENGERS: String = "challengers"
 public let kOWNERID: String = "ownerId"
+public let kSTATUS: String = "status"
 
 public let kEMAIL: String = "email"
 public let kCREATEDAT: String = "createdAt"

--- a/iOS/FuFight-Old/FuFight/Home/HomeViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Home/HomeViewModel.swift
@@ -46,7 +46,7 @@ final class HomeViewModel: BaseAccountViewModel {
                     AccountManager.deleteCurrent()
                     updateError(nil)
                     account.reset()
-                    account.status = .logOut
+                    account.status = .loggedOut
                     if Defaults.isSavingEmailAndPassword {
                         Defaults.savedEmailOrUsername = ""
                         Defaults.savedPassword = ""

--- a/iOS/FuFight/FuFight/App/ContentView.swift
+++ b/iOS/FuFight/FuFight/App/ContentView.swift
@@ -57,7 +57,7 @@ struct ContentView: View {
     //MARK: - Views
     var body: some View {
         switch account.status {
-        case .online:
+        case .loggedIn:
             ZStack(alignment: .bottom) {
                 //Go to home page
                 TabView(selection: $tab) {
@@ -84,7 +84,7 @@ struct ContentView: View {
             //Finish creating account
             createAuthenticationView(step: .onboard)
 
-        case .logOut:
+        case .loggedOut:
             //Log in
             createAuthenticationView(step: .logIn)
         }

--- a/iOS/FuFight/FuFight/Room/Room.swift
+++ b/iOS/FuFight/FuFight/Room/Room.swift
@@ -14,7 +14,7 @@ class Room: Codable {
     ///Player that owns the room
     private(set) var player: FetchedPlayer?
     private(set) var challengers: [FetchedPlayer] = []
-    private(set) var isSearching: Bool = false
+    private(set) var status: Status = .online
 
     var isValid: Bool {
         player != nil && challengers.first != nil
@@ -31,12 +31,6 @@ class Room: Codable {
         self.player = ownerPlayer
     }
 
-    ///Room joiner/enemy initializer
-    init(roomId: String, enemyPlayer: FetchedPlayer) {
-        self.documentId = roomId
-        challengers.append(enemyPlayer)
-    }
-
     init(_ account: Account) {
         self.documentId = account.userId
         self.player = FetchedPlayer(account)
@@ -47,7 +41,7 @@ class Room: Codable {
         case player = "player"
         case challengers = "challengers"
         case ownerId = "ownerId"
-        case isSearching = "isSearching"
+        case status = "status"
     }
 
     func encode(to encoder: Encoder) throws {
@@ -59,14 +53,15 @@ class Room: Codable {
         if !challengers.isEmpty {
             try container.encode(challengers, forKey: .challengers)
         }
-        try container.encode(isSearching, forKey: .isSearching)
+        try container.encode(status.rawValue, forKey: .status)
         try container.encode(ownerId, forKey: .ownerId)
     }
 
     required init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         self.player = try values.decodeIfPresent(FetchedPlayer.self, forKey: .player)
-        self.isSearching = try values.decodeIfPresent(Bool.self, forKey: .isSearching) ?? false
+        let statusId = try values.decodeIfPresent(String.self, forKey: .status)!
+        self.status = Status(rawValue: statusId) ?? .online
         self.challengers = try values.decodeIfPresent(Array<FetchedPlayer>.self, forKey: .challengers) ?? []
         self.documentId = try values.decodeIfPresent(String.self, forKey: .ownerId)!
     }
@@ -86,4 +81,18 @@ class Room: Codable {
 //MARK: - Private extension
 private extension Room  {
 
+}
+
+//MARK: - Custom Room Classes
+extension Room {
+    ///Status for the room owner
+    enum Status: String {
+        case online
+        case offline
+        ///searching for enemy
+        case searching
+        case gaming
+        ///during game over flow
+        case finishing
+    }
 }

--- a/iOS/FuFight/StoreViewModel.swift
+++ b/iOS/FuFight/StoreViewModel.swift
@@ -35,7 +35,7 @@ final class StoreViewModel: BaseAccountViewModel {
                 AccountManager.deleteCurrent()
                 updateError(nil)
                 account.reset()
-                account.status = .logOut
+                account.status = .loggedOut
                 if Defaults.isSavingEmailAndPassword {
                     Defaults.savedEmailOrUsername = ""
                     Defaults.savedPassword = ""


### PR DESCRIPTION
    - Add a `Status` enum to `Room` with case: `online`, `offline`, `isSearching`, `isFighting`, `isFinishing`
        - Renamed 2 cases for `Account.Status` , `online` to `loggedIn`, and `logOut` to `loggedOut`
        - Set `Room`’s `status` to `.searching` when `GameLoadingView` appears
        - When `GameLoadingView` disappears, set `Room`’s `status` to either `.online` or `.gaming` if enemy is successfully found
    - Updated `findAvailableRooms()` to return roomIds of Room that has a status of .searching