### PR TITLE
- Commit 23: Fix room status not getting updated when app is in backg…

### DIFF
--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLoadingViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLoadingViewModel.swift
@@ -72,7 +72,7 @@ final class GameLoadingViewModel: BaseAccountViewModel {
     override func onAppear() {
         super.onAppear()
         enemyPlayer = nil
-        updateRoomStatus(.searching)
+        RoomNetworkManager.updateStatus(to: .searching, roomId: account.userId)
     }
 
     override func onDisappear() {
@@ -84,7 +84,7 @@ final class GameLoadingViewModel: BaseAccountViewModel {
         subscriptions.removeAll()
         if isEnemyFound {
             isEnemyFound = false
-            updateRoomStatus(.gaming)
+            RoomNetworkManager.updateStatus(to: .gaming, roomId: account.userId)
         }
     }
 
@@ -232,16 +232,6 @@ private extension GameLoadingViewModel {
         isEnemyFound = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.didFindEnemy.send(self)
-        }
-    }
-
-    func updateRoomStatus(_ status: Room.Status) {
-        Task {
-            do {
-                try await RoomNetworkManager.updateStatus(to: status, roomId: player.userId)
-            } catch let error {
-                LOGE(error.localizedDescription, from: GameLoadingViewModel.self)
-            }
         }
     }
 }

--- a/iOS/FuFight-Old/FuFight/Home/HomeViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Home/HomeViewModel.swift
@@ -40,7 +40,7 @@ final class HomeViewModel: BaseAccountViewModel {
                         LOGD("Account verified", from: HomeViewModel.self)
                         isAccountVerified = true
                         refreshPlayer()
-                        updateRoomStatus(.online)
+                        RoomNetworkManager.updateStatus(to: .online, roomId: account.userId)
                         return
                     }
                     LOGE("Account is invalid \(account.displayName) with id \(account.userId)", from: HomeViewModel.self)
@@ -62,15 +62,5 @@ final class HomeViewModel: BaseAccountViewModel {
     func refreshPlayer() {
         guard let player = RoomManager.getPlayer() else { return }
         self.player = player
-    }
-
-    func updateRoomStatus(_ status: Room.Status) {
-        Task {
-            do {
-                try await RoomNetworkManager.updateStatus(to: status, roomId: account.userId)
-            } catch let error {
-                LOGE(error.localizedDescription, from: GameLoadingViewModel.self)
-            }
-        }
     }
 }

--- a/iOS/FuFight/FuFight/Room/RoomNetworkManager.swift
+++ b/iOS/FuFight/FuFight/Room/RoomNetworkManager.swift
@@ -86,20 +86,17 @@ extension RoomNetworkManager {
         }
     }
 
-    static func updateStatus(to status: Room.Status, roomId: String) async throws {
-        do {
-            var roomDic: [String: Any] = [kSTATUS: status.rawValue]
-            switch status {
-            case .finishing, .searching:
-                break
-            case .online, .offline, .gaming:
-                roomDic[kCHALLENGERS] = FieldValue.delete()
-            }
-            try await roomsDb.document(roomId).updateData(roomDic)
-            LOGD("Player's room status is updated to: \(status.rawValue)")
-        } catch {
-            throw error
+    static func updateStatus(to status: Room.Status, roomId: String) {
+        var roomDic: [String: Any] = [kSTATUS: status.rawValue]
+        switch status {
+        case .finishing, .searching:
+            break
+        case .online, .offline, .gaming:
+            roomDic[kCHALLENGERS] = FieldValue.delete()
         }
+        let roomFieldsToUpdate: [String] = [kSTATUS, kCHALLENGERS]
+        roomsDb.document(roomId).setData(roomDic, mergeFields: roomFieldsToUpdate)
+        LOGD("Player's room status is updated to: \(status.rawValue)")
     }
 
     ///For room owner to delete room


### PR DESCRIPTION
…round (6/1)

    - The issue was after deleting a `Game` document is a `Task` that `updateRoomStatus()` waits to finish before executing. Removing the Task and wait async call on `RoomNetworkManager.updateStatus()` fixed it since we don’t really care how long room status update takes
    - These changes ensures that all database changes are still made before the app is fully terminated