### PR TITLE
Commit 25: Edit and Show Player’s selected FighterType (6/1 - 6/2)

### DIFF
--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/FetchedPlayer.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/FetchedPlayer.swift
@@ -34,6 +34,7 @@ class FetchedPlayer: PlayerProtocol {
         self.userId = !isRoomOwner ? player.userId : enemyPlayer.userId
         self.moves = !isRoomOwner ? player.moves : enemyPlayer.moves
         self.fighterType = !isRoomOwner ? player.fighterType : enemyPlayer.fighterType
+        LOGD("Fighter type for enemy is \(!isRoomOwner ? player.fighterType : enemyPlayer.fighterType)")
     }
 
     ///Default value/initializer for FetchedPlayer from current logged in account
@@ -41,8 +42,12 @@ class FetchedPlayer: PlayerProtocol {
         self.userId = account.userId
         self.username = account.username!
         self.photoUrl = account.photoUrl!
-        self.fighterType = .samuel
-        self.moves = Moves(attacks: Punch.allCases.compactMap { Attack($0) }, defenses: Dash.allCases.compactMap { Defense($0) })
+        let room = Room.current
+        self.fighterType = room?.player?.fighterType ?? .samuel
+        let attacks = room?.player?.moves.attacks ?? defaultAllPunchAttacks
+        let defenses = room?.player?.moves.defenses ?? defaultAllDashDefenses
+        self.moves = Moves(attacks: attacks, defenses: defenses)
+        LOGD("Fighter type for enemy is \(room?.player?.fighterType ?? .samuel)")
     }
 
     required init(from decoder: Decoder) throws {
@@ -53,8 +58,7 @@ class FetchedPlayer: PlayerProtocol {
         self.photoUrl = try values.decodeIfPresent(URL.self, forKey: .photoUrl)!
         self.moves = try values.decodeIfPresent(Moves.self, forKey: .moves)!
         let fighterId = try values.decodeIfPresent(String.self, forKey: .fighterType)!
-        let fighterType = FighterType(rawValue: fighterId)!
-        self.fighterType = fighterType
+        self.fighterType = FighterType(rawValue: fighterId)!
     }
 }
 

--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLoadingViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/GameLoadingViewModel.swift
@@ -41,7 +41,7 @@ final class GameLoadingViewModel: BaseAccountViewModel {
             }
             .store(in: &subscriptions)
 
-        //After getting a room with player and enemy, create an enemyPlayer
+        //After room owner receives getting a room with player and enemy, create an enemyPlayer
         $room
             .map { room in
                 FetchedPlayer(room: room, isRoomOwner: self.isRoomOwner)
@@ -217,8 +217,6 @@ private extension GameLoadingViewModel {
                     let fetchedGameAsChallenger = try snapshot.data(as: FetchedGame.self)
                     if fetchedGameAsChallenger.ownerId != player.userId {
                         enemyPlayer = fetchedGameAsChallenger.player
-                        LOGD("Challenging to a game against the room owner \(fetchedGameAsChallenger.player.username)")
-                        unsubscribe()
                     } else {
                         TODO("Handle when game created is not the user")
                     }

--- a/iOS/FuFight-Old/FuFight/Helpers/Constants/ConstantKeys.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/Constants/ConstantKeys.swift
@@ -25,6 +25,7 @@ public let kENEMYPHOTOURL: String = "enemyPhotoUrl"
 public let kENEMYMOVES: String = "enemyMoves"
 public let kENEMYFIGHTERTYPE: String = "enemyFighterType"
 
+public let kPLAYER: String = "player"
 public let kCHALLENGERS: String = "challengers"
 public let kOWNERID: String = "ownerId"
 public let kSTATUS: String = "status"

--- a/iOS/FuFight-Old/FuFight/Home/DaePreview.swift
+++ b/iOS/FuFight-Old/FuFight/Home/DaePreview.swift
@@ -12,8 +12,17 @@ import SceneKit
 struct DaePreview: UIViewRepresentable {
     typealias UIViewType = SCNView
 
-    var fighter: FighterType = .samuel
-    var animationType: AnimationType = .idleStand
+    var fighterType: FighterType = .samuel
+    var animationType: AnimationType = .idle
+
+    init(fighterType: FighterType, animationType: AnimationType) {
+        self.fighterType = fighterType
+        self.animationType = animationType
+    }
+
+    init() {
+        self.fighterType = Room.current?.player?.fighterType ?? .samuel
+    }
 
     func makeUIView(context: Context) -> UIViewType {
         let view = SCNView()
@@ -25,10 +34,11 @@ struct DaePreview: UIViewRepresentable {
         view.defaultCameraController.inertiaEnabled = true
         view.defaultCameraController.maximumVerticalAngle = 89
         view.defaultCameraController.minimumVerticalAngle = -89
-        let path = fighter.animationPath(animationType)
-        view.scene = SCNScene(named: path)
         return view
     }
 
-    func updateUIView(_ uiView: UIViewType, context: Context) {}
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+        let path = fighterType.animationPath(animationType)
+        uiView.scene = SCNScene(named: path)
+    }
 }

--- a/iOS/FuFight-Old/FuFight/Home/HomeView.swift
+++ b/iOS/FuFight-Old/FuFight/Home/HomeView.swift
@@ -21,10 +21,6 @@ struct HomeView: View {
                         navigationView
 
                         VStack {
-                            Text("Welcome \(vm.account.displayName)")
-                                .font(mediumTitleFont)
-                                .foregroundStyle(.white)
-
                             Spacer()
                         }
                         .alert(title: vm.alertTitle, message: vm.alertMessage, isPresented: $vm.isAlertPresented)
@@ -66,10 +62,22 @@ struct HomeView: View {
     }
 
     var navigationView: some View {
-        HStack {
-            accountImage
+        ZStack {
+            HStack {
+                accountImage
 
-            Spacer()
+                Spacer()
+            }
+            
+            HStack {
+                Spacer()
+
+                Text("Welcome \(vm.account.displayName)")
+                    .font(mediumTitleFont)
+                    .foregroundStyle(.white)
+
+                Spacer()
+            }
         }
         .padding(.horizontal, smallerHorizontalPadding)
     }

--- a/iOS/FuFight/FuFight/Room/RoomManager.swift
+++ b/iOS/FuFight/FuFight/Room/RoomManager.swift
@@ -48,8 +48,15 @@ class RoomManager {
             return room.player
         } else if let account = Account.current {
             saveCurrent(Room(account))
+            return getPlayer()
         }
-        return getCurrent()?.player
+        return nil
+    }
+
+    static func savePlayer(player: FetchedPlayer) {
+        guard let room = getCurrent() else { return }
+        room.updatePlayer(player: player)
+        saveCurrent(room)
     }
 
     static func deleteCurrent() {

--- a/iOS/FuFight/FuFight/Room/RoomNetworkManager.swift
+++ b/iOS/FuFight/FuFight/Room/RoomNetworkManager.swift
@@ -36,17 +36,6 @@ extension RoomNetworkManager {
         }
     }
 
-//    static func updateRoom(_ room: Room) async throws {
-//        do {
-//            let userId = room.player!.userId
-//            let roomDocument = roomsDb.document(userId)
-//            try await roomDocument.updateData(roomDocument.asDictionary())
-//            LOGD("Room updated for roomId: \(userId)")
-//        } catch {
-//            throw error
-//        }
-//    }
-
     ///Fetch an available room if there's any available. Return avaialble roomIds
     static func findAvailableRooms(userId: String) async throws -> [String] {
         let isRoomSearchingFilter: Filter = .whereField(kSTATUS, isEqualTo: Room.Status.searching.rawValue)
@@ -121,12 +110,12 @@ extension RoomNetworkManager {
         }
     }
 
-    ///For enemy to leave a room
-    static func leaveRoom(_ room: Room?) async throws {
-        guard let room else { return }
+    ///Updates room's owner in the database
+    static func updateOwner(_ player: FetchedPlayer) async throws {
         do {
-            try roomsDb.document(room.ownerId).setData(from: room, merge: true)
-            LOGD("User left room as enemy with room id: \(room.ownerId)")
+            let roomDocument = roomsDb.document(player.userId)
+            try await roomDocument.updateData([kPLAYER: player.asDictionary()])
+            LOGD("Room's owner is updated successfully: \(player.username)")
         } catch {
             throw error
         }

--- a/iOS/FuFight/FuFight/Room/RoomView.swift
+++ b/iOS/FuFight/FuFight/Room/RoomView.swift
@@ -13,19 +13,20 @@ struct RoomView: View {
     var body: some View {
         GeometryReader { proxy in
             ScrollView {
-                VStack {
-                    navigationView
+                ZStack {
+                    fighterView
 
                     VStack {
-                        movesView
+                        navigationView
 
-                        Spacer()
+                        VStack {
+                            movesView
+                        }
+                        .alert(title: vm.alertTitle, message: vm.alertMessage, isPresented: $vm.isAlertPresented)
+                        .padding()
                     }
-                    .alert(title: vm.alertTitle, message: vm.alertMessage, isPresented: $vm.isAlertPresented)
-                    .padding()
                 }
             }
-            .edgesIgnoringSafeArea([.bottom, .leading, .trailing])
             .overlay {
                 LoadingView(message: vm.loadingMessage)
             }
@@ -33,16 +34,6 @@ struct RoomView: View {
                 backgroundImage
                     .padding(.leading, 30)
             )
-            .safeAreaInset(edge: .bottom) {
-                VStack {
-//                    playButton
-//
-//                    offlinePlayButton
-//
-//                    practiceButton
-                }
-                .padding(.bottom)
-            }
             .navigationBarHidden(true)
             .frame(maxWidth: .infinity)
         }
@@ -56,48 +47,30 @@ struct RoomView: View {
     }
 
     var navigationView: some View {
-        HStack {
-            Spacer()
+        ZStack {
+            HStack {
+                Spacer()
 
-            Text("Edit Fighter")
-                .font(mediumTitleFont)
-                .foregroundStyle(.white)
+                Button {
+                    vm.switchButtonSelected()
+                } label: {
+                    Image(systemName: "arrow.2.squarepath")
+                        .foregroundStyle(.white)
+                }
+            }
 
-            Spacer()
+            HStack {
+                Spacer()
+
+                Text("Edit")
+                    .font(mediumTitleFont)
+                    .foregroundStyle(.white)
+
+                Spacer()
+            }
         }
         .padding(.horizontal, smallerHorizontalPadding)
     }
-
-    var accountImage: some View {
-        NavigationLink(destination: AccountView(vm: AccountViewModel(account: vm.account))) {
-            AccountImage(url: vm.account.photoUrl, radius: 30)
-        }
-    }
-
-//    var playButton: some View {
-//        Button {
-//            vm.transitionToLoading.send(vm)
-//        } label: {
-//            Image("playButton")
-//                .frame(width: 200)
-//        }
-//    }
-
-//    var offlinePlayButton: some View {
-//        Button {
-//            vm.transitionToOffline.send(vm)
-//        } label: {
-//            Text("Offline Play")
-//                .padding(6)
-//                .frame(maxWidth: .infinity)
-//                .foregroundStyle(Color(uiColor: .systemBackground))
-//                .font(.title)
-//                .background(Color(uiColor: .label))
-//                .clipShape(RoundedRectangle(cornerRadius: 16))
-//        }
-//        .padding(.horizontal)
-//        .padding(.bottom, 4)
-//    }
 
     @ViewBuilder var movesView: some View {
         if vm.player != nil {
@@ -109,7 +82,12 @@ struct RoomView: View {
                     vm.defenseSelected($0)
                 },
                 playerType: vm.playerType)
-//            .frame(width: playerType.isEnemy ? 100 : nil, height: playerType.isEnemy ? 120 : nil)
+        }
+    }
+
+    @ViewBuilder var fighterView: some View {
+        if vm.player != nil {
+            DaePreview(fighterType: vm.player.fighterType, animationType: vm.animationType)
         }
     }
 }

--- a/iOS/FuFight/StoreViewModel.swift
+++ b/iOS/FuFight/StoreViewModel.swift
@@ -17,32 +17,4 @@ final class StoreViewModel: BaseAccountViewModel {
     //    let transitionToAccount = PassthroughSubject<StoreViewModel, Never>()
 
     //MARK: - Public Methods
-    ///Make sure account is valid at least once
-    @MainActor func verifyAccount() {
-        Task {
-            do {
-                if try await AccountNetworkManager.isAccountValid(userId: account.userId) {
-                    self.player = Player(userId: account.userId, photoUrl: account.photoUrl ?? fakePhotoUrl,
-                                         username: Account.current?.displayName ?? "",
-                                         hp: defaultMaxHp,
-                                         maxHp: defaultMaxHp,
-                                         fighter: Fighter(type: .samuel, isEnemy: false),
-                                         state: PlayerState(boostLevel: .none, hasSpeedBoost: false),
-                                         moves: Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses))
-                    return
-                }
-                LOGE("Account is invalid \(account.displayName) with id \(account.userId)", from: StoreViewModel.self)
-                AccountManager.deleteCurrent()
-                updateError(nil)
-                account.reset()
-                account.status = .loggedOut
-                if Defaults.isSavingEmailAndPassword {
-                    Defaults.savedEmailOrUsername = ""
-                    Defaults.savedPassword = ""
-                }
-            } catch {
-                updateError(MainError(type: .deletingUser, message: error.localizedDescription))
-            }
-        }
-    }
 }


### PR DESCRIPTION
    - Add a way to switch FetchedPlayer’s FighterType in RoomView between .samuel and .clara
    - Add a way to load and save Room.player’s fighter type locally and to Firestore
    - Reload the DaePreview() when fighter type button is tapped
    - During online game, show both player’s selected FighterType
        - Fixed issue where loaded fighterType for enemy is wrong because the initial FetchedGame is incorrect. However, removing the premature unsubscribe fixed and showed the correct fighterType