### PR TITLE
Commit 26: Sync both online player’s hasSpeedBoost property (6/2 -6/3)

### DIFF
--- a/iOS/FuFight-Old/FuFight/Game/GameLoading/FetchedGame.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameLoading/FetchedGame.swift
@@ -12,6 +12,15 @@ struct FetchedGame {
     var ownerId: String { documentId! }
     private(set) var player: FetchedPlayer
     private(set) var enemyPlayer: FetchedPlayer
+    let ownerInitiallyHasSpeedBoost: Bool
+
+    ///Initializer for the owner
+    init(player: FetchedPlayer, enemyPlayer: FetchedPlayer, ownerInitiallyHasSpeedBoost: Bool) {
+        self.documentId = player.userId
+        self.player = player
+        self.enemyPlayer = enemyPlayer
+        self.ownerInitiallyHasSpeedBoost = ownerInitiallyHasSpeedBoost
+    }
 }
 
 //MARK: - Codable extension
@@ -20,6 +29,7 @@ extension FetchedGame: Codable {
         case ownerId = "ownerId"
         case player = "userPlayer"
         case enemyPlayer = "enemyPlayer"
+        case ownerInitiallyHasSpeedBoost = "ownerInitiallyHasSpeedBoost"
     }
 
     func encode(to encoder: Encoder) throws {
@@ -27,6 +37,7 @@ extension FetchedGame: Codable {
         try container.encode(ownerId, forKey: .ownerId)
         try container.encode(player, forKey: .player)
         try container.encode(enemyPlayer, forKey: .enemyPlayer)
+        try container.encode(ownerInitiallyHasSpeedBoost, forKey: .ownerInitiallyHasSpeedBoost)
     }
 
     init(from decoder: Decoder) throws {
@@ -34,5 +45,6 @@ extension FetchedGame: Codable {
         self.documentId = try values.decodeIfPresent(String.self, forKey: .ownerId)!
         self.player = try values.decodeIfPresent(FetchedPlayer.self, forKey: .player)!
         self.enemyPlayer = try values.decodeIfPresent(FetchedPlayer.self, forKey: .enemyPlayer)!
+        self.ownerInitiallyHasSpeedBoost = try values.decodeIfPresent(Bool.self, forKey: .ownerInitiallyHasSpeedBoost)!
     }
 }

--- a/iOS/FuFight-Old/FuFight/Game/GameNetworkManager.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameNetworkManager.swift
@@ -16,16 +16,12 @@ class GameNetworkManager {
 
 //MARK: - Game methods
 extension GameNetworkManager {
-    static func createGameFromRoom(_ room: Room?) async throws {
-        guard let room, let player = room.player, let enemyPlayer = room.challengers.first else { return }
+    static func createGameFromRoom(_ room: Room, ownerInitiallyHasSpeedBoost: Bool) async throws {
+        guard let player = room.player, let enemyPlayer = room.challengers.first else { return }
         do {
-            let gameDic: [String: Any] = [
-                kOWNERID: room.ownerId,
-                kUSERPLAYER: try player.asDictionary(),
-                kENEMYPLAYER: try enemyPlayer.asDictionary(),
-            ]
-            try await gamesDb.document(player.userId).setData(gameDic)
-            LOGD("createGameFromRoom() Room owner \(player.username) created a Game document against \(enemyPlayer.username)")
+            let game = FetchedGame(player: player, enemyPlayer: enemyPlayer, ownerInitiallyHasSpeedBoost: ownerInitiallyHasSpeedBoost)
+            try await gamesDb.document(player.userId).setData(game.asDictionary())
+            LOGD("Room owner created a Game document against \(enemyPlayer.username). With owner has initial speed boost? \(game.ownerInitiallyHasSpeedBoost)")
         } catch {
             throw error
         }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/GameViewModel.swift
@@ -131,9 +131,6 @@ class GameViewModel: BaseViewModel {
 //MARK: - Private Methods
 private extension GameViewModel {
     func startNewGame() {
-        let hasSpeedBoost = Bool.random()
-        player.state.setSpeedBoost(to: hasSpeedBoost)
-        enemyPlayer?.state.setSpeedBoost(to: !hasSpeedBoost)
         isDefenderAlive = true
         createNewRound()
     }

--- a/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
+++ b/iOS/FuFight-Old/FuFight/Game/GameView/Model/Player.swift
@@ -12,9 +12,9 @@ struct PlayerState {
     ///Keeps track of which player gets the speed boost next round. True if current player attacked first and landed it
     private(set) var hasSpeedBoost: Bool //TODO: Multiplayer game mode should be synced between games
 
-    init(boostLevel: BoostLevel, hasSpeedBoost: Bool) {
+    init(boostLevel: BoostLevel, initiallyHasSpeedBoost: Bool) {
         self.boostLevel = boostLevel
-        self.hasSpeedBoost = hasSpeedBoost
+        self.hasSpeedBoost = initiallyHasSpeedBoost
     }
 
     mutating func upgradeBoost() {
@@ -71,7 +71,7 @@ class Player: PlayerProtocol {
     }
 
     ///Room owner's initializer
-    init(fetchedPlayer: FetchedPlayer, isEnemy: Bool) {
+    init(fetchedPlayer: FetchedPlayer, isEnemy: Bool, initiallyHasSpeedBoost: Bool) {
         self.photoUrl = fetchedPlayer.photoUrl
         self.username = fetchedPlayer.username
         self.userId = fetchedPlayer.userId
@@ -82,8 +82,7 @@ class Player: PlayerProtocol {
         self.rounds = []
         self.speed = 0
         self.isEnemy = isEnemy
-        //TODO: hasSpeedBoost should not be false
-        self.state = .init(boostLevel: .none, hasSpeedBoost: false)
+        self.state = PlayerState(boostLevel: .none, initiallyHasSpeedBoost: initiallyHasSpeedBoost)
     }
 
     func loadAnimations() {
@@ -133,6 +132,8 @@ class Player: PlayerProtocol {
         state.resetBoost()
         moves.resetMoves()
         fighter.resumeAnimations()
+        //TODO: sync initiallyHasSpeedBoost with enemy when playing an online game. Or restart the whole GameView
+        state = PlayerState(boostLevel: .none, initiallyHasSpeedBoost: false)
     }
 }
 

--- a/iOS/FuFight-Old/FuFight/Helpers/Constants/ConstantKeys.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/Constants/ConstantKeys.swift
@@ -28,6 +28,7 @@ public let kENEMYFIGHTERTYPE: String = "enemyFighterType"
 public let kPLAYER: String = "player"
 public let kCHALLENGERS: String = "challengers"
 public let kOWNERID: String = "ownerId"
+public let kOWNERINITIALLYHASSPEEDBOOST: String = "ownerInitiallyHasSpeedBoost"
 public let kSTATUS: String = "status"
 
 public let kEMAIL: String = "email"

--- a/iOS/FuFight-Old/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight-Old/FuFight/Helpers/Constants/Constants.swift
@@ -122,7 +122,7 @@ let fakePlayer = Player(userId: "fakePlayer",
                         hp: defaultMaxHp,
                         maxHp: defaultMaxHp,
                         fighter: Fighter(type: .samuel, isEnemy: false),
-                        state: PlayerState(boostLevel: .none, hasSpeedBoost: false),
+                        state: PlayerState(boostLevel: .none, initiallyHasSpeedBoost: false),
                         moves: Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses))
 let fakeEnemyPlayer = Player(userId: "fakeEnemyPlayer",
                              photoUrl: fakePhotoUrl,
@@ -130,7 +130,7 @@ let fakeEnemyPlayer = Player(userId: "fakeEnemyPlayer",
                              hp: defaultEnemyHp,
                              maxHp: defaultEnemyHp,
                              fighter: Fighter(type: .clara, isEnemy: true),
-                             state: PlayerState(boostLevel: .none, hasSpeedBoost: false),
+                             state: PlayerState(boostLevel: .none, initiallyHasSpeedBoost: false),
                              moves: Moves(attacks: defaultAllPunchAttacks, defenses: defaultAllDashDefenses))
 
 //MARK: - Constant Methods

--- a/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
+++ b/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
@@ -71,25 +71,14 @@ class HomeRouter: ObservableObject {
     }
 
     func transitionTo(route: GameRoute, vm: HomeViewModel) {
-        let player = Player(fetchedPlayer: vm.player!, isEnemy: false)
         switch route {
         case .onlineGame:
             //show loading and let loading handle transition to online game
-            if let enemyPlayer = vm.enemyPlayer {
-                TODO("Handle returning to current online game for \(player.username) vs \(enemyPlayer.username)")
-            } else {
-//                let nextVm: HomeRoute = .loading(vm: makeLoadingViewModel(player: vm.player!,
-//                                                                          enemyPlayer: nil,
-//                                                                          account: vm.account))
-                let nextVm: HomeRoute = .loading(vm: makeLoadingViewModel(account: vm.account))
-                navigationPath.append(nextVm)
-            }
-        case .offlineGame:
-            navigationPath.append(.game(vm: makeGameViewModel(isPracticeMode: false, 
-                                                              player: player,
-                                                              enemyPlayer: fakeEnemyPlayer)))
-        case .practice:
-            navigationPath.append(.game(vm: makeGameViewModel(isPracticeMode: true, 
+            navigationPath.append(.loading(vm: makeLoadingViewModel(account: vm.account)))
+        case .offlineGame, .practice:
+            let isPracticeMode = route == .practice
+            let player = Player(fetchedPlayer: vm.player!, isEnemy: false, initiallyHasSpeedBoost: true)
+            navigationPath.append(.game(vm: makeGameViewModel(isPracticeMode: isPracticeMode,
                                                               player: player,
                                                               enemyPlayer: fakeEnemyPlayer)))
         }
@@ -120,7 +109,10 @@ class HomeRouter: ObservableObject {
 
     func didCompleteLoading(vm: GameLoadingViewModel) {
         if let enemyPlayer = vm.enemyPlayer {
-            navigationPath.append(.game(vm: makeGameViewModel(isPracticeMode: false, player: Player(fetchedPlayer: vm.player, isEnemy: false), enemyPlayer: Player(fetchedPlayer: enemyPlayer, isEnemy: true))))
+            let initiallyHasSpeedBoost = vm.initiallyHasSpeedBoost
+            let player = Player(fetchedPlayer: vm.player, isEnemy: false, initiallyHasSpeedBoost: initiallyHasSpeedBoost)
+            let enemy = Player(fetchedPlayer: enemyPlayer, isEnemy: true, initiallyHasSpeedBoost: !initiallyHasSpeedBoost)
+            navigationPath.append(.game(vm: makeGameViewModel(isPracticeMode: false, player: player, enemyPlayer: enemy)))
         }
     }
 


### PR DESCRIPTION
    - Added `ownerInitiallyHasSpeedBoost` to `Room`
        - Set `ownerInitiallyHasSpeedBoost` when FetchedGame is created
    - Refactored `GameLoadingViewModel` to not set `enemyPlayer` when room is set more than once, ensure document has no pendingWrites, improved naming, and documentations, TODOs
    - Make sure both players know which player has the initial speed boost and are in sync
        - Player’s `initiallyHasSpeedBoost` is not correctly synced sometimes was fixed by adding a delay after enemyPlayer has been set
    - Also made sure properties in `GameLoadingViewModel` are properly resets when the view disappears