### PR TITLE
Commit 36: Make each player create their own Game document (6/8-6/11)

### DIFF
--- a/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
+++ b/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
@@ -107,10 +107,13 @@ class HomeRouter: ObservableObject {
     }
 
     func didCompleteLoading(vm: GameLoadingViewModel) {
-        guard let enemy = vm.enemy else { return }
+        guard let game = vm.game else {
+            LOGE("Failed to load GameView with missing game")
+            return
+        }
         let initiallyHasSpeedBoost = vm.initiallyHasSpeedBoost
-        let player = Player(fetchedPlayer: vm.player, isEnemy: false, isGameOwner: vm.isRoomOwner, initiallyHasSpeedBoost: initiallyHasSpeedBoost)
-        let enemyPlayer = Player(fetchedPlayer: enemy, isEnemy: true, isGameOwner: !vm.isRoomOwner, initiallyHasSpeedBoost: !initiallyHasSpeedBoost)
+        let player = Player(fetchedPlayer: game.player, isEnemy: false, isGameOwner: vm.isRoomOwner, initiallyHasSpeedBoost: game.playerInitiallyHasSpeedBoost)
+        let enemyPlayer = Player(fetchedPlayer: game.enemy, isEnemy: true, isGameOwner: !vm.isRoomOwner, initiallyHasSpeedBoost: !game.playerInitiallyHasSpeedBoost)
         navigationPath.append(.game(vm: makeGameViewModel(player: player, enemy: enemyPlayer, gameMode: .onlineGame)))
     }
 

--- a/iOS/FuFight/FuFight/Game/GameLoading/FetchedGame.swift
+++ b/iOS/FuFight/FuFight/Game/GameLoading/FetchedGame.swift
@@ -7,45 +7,48 @@
 
 import FirebaseFirestore
 
-///This class represents a Game document. The authenticated user can be the game's owner or an challenger
+///This class represents a Game document. The authenticated user can be the game's player or an enemy
 struct FetchedGame {
     @DocumentID private var documentId: String?
-    var ownerId: String { documentId! }
-    private(set) var owner: FetchedPlayer
-    private(set) var challenger: FetchedPlayer
-    let ownerInitiallyHasSpeedBoost: Bool
+    private(set) var player: FetchedPlayer
+    private(set) var enemy: FetchedPlayer
+    let playerInitiallyHasSpeedBoost: Bool
 
-    ///Initializer for the owner
-    init(owner: FetchedPlayer, challenger: FetchedPlayer, ownerInitiallyHasSpeedBoost: Bool) {
-        self.documentId = owner.userId
-        self.owner = owner
-        self.challenger = challenger
-        self.ownerInitiallyHasSpeedBoost = ownerInitiallyHasSpeedBoost
+    private(set) var selectedMoves: [SelectedMove] = []
+
+    ///Initializer for the player
+    init(player: FetchedPlayer, enemy: FetchedPlayer, playerInitiallyHasSpeedBoost: Bool) {
+        self.documentId = player.userId
+        self.player = player
+        self.enemy = enemy
+        self.playerInitiallyHasSpeedBoost = playerInitiallyHasSpeedBoost
     }
 }
 
 //MARK: - Codable extension
 extension FetchedGame: Codable {
     private enum CodingKeys : String, CodingKey {
-        case ownerId = "ownerId"
-        case owner = "owner"
-        case challenger = "challenger"
-        case ownerInitiallyHasSpeedBoost = "ownerInitiallyHasSpeedBoost"
+        case playerId = "playerId"
+        case player = "player"
+        case enemy = "enemy"
+        case playerInitiallyHasSpeedBoost = "playerInitiallyHasSpeedBoost"
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(ownerId, forKey: .ownerId)
-        try container.encode(owner, forKey: .owner)
-        try container.encode(challenger, forKey: .challenger)
-        try container.encode(ownerInitiallyHasSpeedBoost, forKey: .ownerInitiallyHasSpeedBoost)
+        if let documentId {
+            try container.encode(documentId, forKey: .playerId)
+        }
+        try container.encode(player, forKey: .player)
+        try container.encode(enemy, forKey: .enemy)
+        try container.encode(playerInitiallyHasSpeedBoost, forKey: .playerInitiallyHasSpeedBoost)
     }
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        self.documentId = try values.decodeIfPresent(String.self, forKey: .ownerId)!
-        self.ownerInitiallyHasSpeedBoost = try values.decodeIfPresent(Bool.self, forKey: .ownerInitiallyHasSpeedBoost)!
-        self.owner = try values.decodeIfPresent(FetchedPlayer.self, forKey: .owner) ?? FetchedPlayer(fakePlayer)
-        self.challenger = try values.decodeIfPresent(FetchedPlayer.self, forKey: .challenger) ?? FetchedPlayer(fakeEnemyPlayer)
+        self.documentId = try values.decodeIfPresent(String.self, forKey: .playerId)!
+        self.playerInitiallyHasSpeedBoost = try values.decodeIfPresent(Bool.self, forKey: .playerInitiallyHasSpeedBoost)!
+        self.player = try values.decodeIfPresent(FetchedPlayer.self, forKey: .player) ?? FetchedPlayer(fakePlayer)
+        self.enemy = try values.decodeIfPresent(FetchedPlayer.self, forKey: .enemy) ?? FetchedPlayer(fakeEnemyPlayer)
     }
 }

--- a/iOS/FuFight/FuFight/Game/GameLoading/FetchedPlayer.swift
+++ b/iOS/FuFight/FuFight/Game/GameLoading/FetchedPlayer.swift
@@ -26,14 +26,14 @@ class FetchedPlayer: PlayerProtocol {
     ///Creates an enemy player from the room
     init?(room: Room?, isRoomOwner: Bool) {
         guard let room,
-              let owner = room.owner,
               let enemyPlayer = room.challengers.first
         else { return nil }
-        self.photoUrl = !isRoomOwner ? owner.photoUrl : enemyPlayer.photoUrl
-        self.username = !isRoomOwner ? owner.username : enemyPlayer.username
-        self.userId = !isRoomOwner ? owner.userId : enemyPlayer.userId
-        self.moves = !isRoomOwner ? owner.moves : enemyPlayer.moves
-        self.fighterType = !isRoomOwner ? owner.fighterType : enemyPlayer.fighterType
+        let player = room.player
+        self.photoUrl = !isRoomOwner ? player.photoUrl : enemyPlayer.photoUrl
+        self.username = !isRoomOwner ? player.username : enemyPlayer.username
+        self.userId = !isRoomOwner ? player.userId : enemyPlayer.userId
+        self.moves = !isRoomOwner ? player.moves : enemyPlayer.moves
+        self.fighterType = !isRoomOwner ? player.fighterType : enemyPlayer.fighterType
     }
 
     ///Default value/initializer for FetchedPlayer from current logged in account
@@ -42,9 +42,9 @@ class FetchedPlayer: PlayerProtocol {
         self.username = account.username!
         self.photoUrl = account.photoUrl!
         let room = Room.current
-        self.fighterType = room?.owner?.fighterType ?? .samuel
-        let attacks = room?.owner?.moves.attacks ?? defaultAllPunchAttacks
-        let defenses = room?.owner?.moves.defenses ?? defaultAllDashDefenses
+        self.fighterType = room?.player.fighterType ?? .samuel
+        let attacks = room?.player.moves.attacks ?? defaultAllPunchAttacks
+        let defenses = room?.player.moves.defenses ?? defaultAllDashDefenses
         self.moves = Moves(attacks: attacks, defenses: defenses)
     }
 

--- a/iOS/FuFight/FuFight/Game/GameView/GameView.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/GameView.swift
@@ -61,6 +61,10 @@ struct GameView: View {
             vm.decrementTimeByOneSecond()
         }
         .toolbar(.hidden, for: .tabBar)
+        .task {
+            //Must be started here in order to avoid duplicated calls on createNewRound()
+            vm.updateState(.starting)
+        }
     }
 
     var timerView: some View {

--- a/iOS/FuFight/FuFight/Game/GameView/Model/Attack.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Attack.swift
@@ -7,16 +7,16 @@
 
 import SwiftUI
 
-enum AttackPosition: Int {
-    case leftLight = 1
-    case rightLight = 2
-    case leftMedium = 3
-    case rightMedium = 4
-    case leftHard = 5
-    case rightHard = 6
+enum AttackPosition: String {
+    case leftLight
+    case rightLight
+    case leftMedium
+    case rightMedium
+    case leftHard
+    case rightHard
 
     var isLeft: Bool {
-        return rawValue % 2 == 1
+        return self == .leftLight || self == .leftMedium || self == .leftHard
     }
 }
 

--- a/iOS/FuFight/FuFight/Game/GameView/Model/Defense.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Defense.swift
@@ -7,11 +7,11 @@
 
 import SwiftUI
 
-enum DefensePosition: Int {
-    case forward = 1
-    case left = 2
-    case backward = 3
-    case right = 4
+enum DefensePosition: String {
+    case forward
+    case left
+    case backward
+    case right
 }
 
 protocol DefenseTypeProtocol: DefenseProtocol, Move {}

--- a/iOS/FuFight/FuFight/Game/GameView/Model/Player.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Player.swift
@@ -9,11 +9,13 @@ import Foundation
 
 struct PlayerState {
     private(set) var boostLevel: BoostLevel
+    let initiallyHasSpeedBoost: Bool
     ///Keeps track of which player gets the speed boost next round. True if current player attacked first and landed it
     private(set) var hasSpeedBoost: Bool //TODO: Multiplayer game mode should be synced between games
 
     init(boostLevel: BoostLevel, initiallyHasSpeedBoost: Bool) {
         self.boostLevel = boostLevel
+        self.initiallyHasSpeedBoost = initiallyHasSpeedBoost
         self.hasSpeedBoost = initiallyHasSpeedBoost
     }
 

--- a/iOS/FuFight/FuFight/Game/GameView/Model/SelectedMove.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/SelectedMove.swift
@@ -7,14 +7,6 @@
 
 import Foundation
 
-struct PlayerDocument: Codable {
-    var selectedMoves: [SelectedMove]
-
-    init(rounds: [Round]) {
-        self.selectedMoves = rounds.compactMap { SelectedMove(round: $0) }
-    }
-}
-
 struct SelectedMove: Codable {
     var attackPosition: AttackPosition?
     var defensePosition: DefensePosition?
@@ -37,17 +29,13 @@ struct SelectedMove: Codable {
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        if let attackPositionId = try values.decodeIfPresent(Int.self, forKey: .attackPosition),
+        if let attackPositionId = try values.decodeIfPresent(String.self, forKey: .attackPosition),
            let attackPosition = AttackPosition(rawValue: attackPositionId) {
             self.attackPosition = attackPosition
-        } else {
-//            LOGD("No attack position")
         }
-        if let defensePositionId = try values.decodeIfPresent(Int.self, forKey: .defensePosition),
+        if let defensePositionId = try values.decodeIfPresent(String.self, forKey: .defensePosition),
            let defensePosition = DefensePosition(rawValue: defensePositionId) {
             self.defensePosition = defensePosition
-        } else {
-//            LOGD("No defense position")
         }
     }
 }

--- a/iOS/FuFight/FuFight/Room/Room.swift
+++ b/iOS/FuFight/FuFight/Room/Room.swift
@@ -9,66 +9,60 @@ import FirebaseFirestore
 
 ///Represent a single Room in the database. This class represents the public data for an Account
 class Room: Identifiable, Equatable, Codable {
-    @DocumentID private var documentId: String?
-    var ownerId: String { documentId! }
+    @DocumentID var documentId: String?
     ///Player that owns the room
-    private(set) var owner: FetchedPlayer?
-    private(set) var challengers: [FetchedPlayer] = []
+    var player: FetchedPlayer
+    var challengers: [FetchedPlayer] = []
     private(set) var status: Status = .online
-
-    var isValid: Bool {
-        owner != nil && challengers.first != nil
-    }
 
     ///Returns the currently signed in account's room
     static var current: Room? {
         return RoomManager.getCurrent()
     }
 
-    ///Room owner initializer
-    init(ownerPlayer: FetchedPlayer) {
-        self.documentId = ownerPlayer.userId
-        self.owner = ownerPlayer
+    ///Room player initializer
+    init(player: FetchedPlayer) {
+        self.documentId = player.userId
+        self.player = player
     }
 
     init(_ account: Account) {
         self.documentId = account.userId
-        self.owner = FetchedPlayer(account)
+        self.player = FetchedPlayer(account)
     }
 
     //MARK: - Codable Requirements
     private enum CodingKeys : String, CodingKey {
-        case owner = "owner"
+        case player = "player"
         case challengers = "challengers"
-        case ownerId = "ownerId"
+        case playerId = "playerId"
         case status = "status"
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        //This if let prevents writes to the database where the value is null
-        if let owner {
-            try container.encode(owner, forKey: .owner)
-        }
+        try container.encode(player, forKey: .player)
         if !challengers.isEmpty {
             try container.encode(challengers, forKey: .challengers)
         }
         try container.encode(status.rawValue, forKey: .status)
-        try container.encode(ownerId, forKey: .ownerId)
+        if let documentId {
+            try container.encode(documentId, forKey: .playerId)
+        }
     }
 
     required init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        self.owner = try values.decodeIfPresent(FetchedPlayer.self, forKey: .owner)
+        self.player = try values.decodeIfPresent(FetchedPlayer.self, forKey: .player)!
         let statusId = try values.decodeIfPresent(String.self, forKey: .status)!
         self.status = Status(rawValue: statusId) ?? .online
         self.challengers = try values.decodeIfPresent(Array<FetchedPlayer>.self, forKey: .challengers) ?? []
-        self.documentId = try values.decodeIfPresent(String.self, forKey: .ownerId)!
+        self.documentId = try values.decodeIfPresent(String.self, forKey: .playerId)!
     }
     
     //MARK: Equatable and Identifiable requirements
     static func == (lhs: Room, rhs: Room) -> Bool {
-        lhs.ownerId == rhs.ownerId
+        lhs.documentId! == rhs.documentId!
     }
 
     //MARK: - Public Methods
@@ -78,8 +72,12 @@ class Room: Identifiable, Equatable, Codable {
         }
     }
 
-    func updateOwner(owner: FetchedPlayer?) {
-        self.owner = owner
+    func updatePlayer(player: FetchedPlayer) {
+        self.player = player
+    }
+
+    func addChallenger(player: FetchedPlayer) {
+        challengers.append(player)
     }
 }
 
@@ -90,7 +88,7 @@ private extension Room  {
 
 //MARK: - Custom Room Classes
 extension Room {
-    ///Status for the room owner
+    ///Status for the room player
     enum Status: String {
         case online
         case offline

--- a/iOS/FuFight/FuFight/Room/RoomManager.swift
+++ b/iOS/FuFight/FuFight/Room/RoomManager.swift
@@ -45,7 +45,7 @@ class RoomManager {
 
     static func getPlayer() -> FetchedPlayer? {
         if let room = getCurrent() {
-            return room.owner
+            return room.player
         } else if let account = Account.current {
             saveCurrent(Room(account))
             return getPlayer()
@@ -55,7 +55,7 @@ class RoomManager {
 
     static func savePlayer(player: FetchedPlayer) {
         guard let room = getCurrent() else { return }
-        room.updateOwner(owner: player)
+        room.player = player
         saveCurrent(room)
     }
 

--- a/iOS/FuFight/FuFight/Room/RoomViewModel.swift
+++ b/iOS/FuFight/FuFight/Room/RoomViewModel.swift
@@ -48,7 +48,7 @@ private extension RoomViewModel {
 
     func updatePlayer(with updatedPlayer: FetchedPlayer) {
         guard let currentRoom = RoomManager.getCurrent() else { return }
-        currentRoom.updateOwner(owner: updatedPlayer)
+        currentRoom.updatePlayer(player: player)
         Task {
             try await RoomNetworkManager.updateOwner(updatedPlayer)
         }

--- a/iOS/FuFight/Helpers/Constants/ConstantKeys.swift
+++ b/iOS/FuFight/Helpers/Constants/ConstantKeys.swift
@@ -32,12 +32,12 @@ public let kLEVEL: String = "level"
 public let kRESULT: String = "result"
 
 //Room Keys
-public let kOWNER: String = "owner"
-public let kCHALLENGER: String = "challenger"
+public let kPLAYER: String = "player"
+public let kENEMY: String = "enemy"
 
 public let kCHALLENGERS: String = "challengers"
-public let kOWNERID: String = "ownerId"
-public let kOWNERINITIALLYHASSPEEDBOOST: String = "ownerInitiallyHasSpeedBoost"
+public let kPLAYERID: String = "playerId"
+public let kPLAYERINITIALLYHASSPEEDBOOST: String = "playerInitiallyHasSpeedBoost"
 public let kSTATUS: String = "status"
 
 //Selected Move Keys

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/MainError.swift
@@ -29,6 +29,7 @@ enum MainErrorType {
     case reauthenticatingUser
     case noOpponentFound
     case updatingAccountOrRoom
+    case noDocumentToUpdate
 
     var title: String {
         switch self {
@@ -74,6 +75,8 @@ enum MainErrorType {
             "Error finding opponent"
         case .updatingAccountOrRoom:
             "Error updating account's data"
+        case .noDocumentToUpdate:
+            "Attempting to update a data that does not exist"
         }
     }
 }
@@ -95,5 +98,12 @@ struct MainError {
         self.type = type
         self.title = type.title
         self.message = message
+    }
+
+    init?(error: Error) {
+        if error.localizedDescription.contains("No document to update") {
+            self.init(type: .noDocumentToUpdate, message: "")
+        }
+        return nil
     }
 }


### PR DESCRIPTION
    - Rename `FetchedGame.owner` into `player` and `FetchedGame.challenger` into `enemy`
    - Remove `isGameOwner` property
    - Put selected moves inside FetchedGame
    - Made AttackPosition and DefensePosition’s value to be string instead of int
    - Renamed `findAvailableRooms(userId: String) async throws` into `getRoomsWithStatus(_ status: Room.Status) **async** **throws** -> [Room]`
    - Renamed `createOrRejoinRoom()` into `waitForChallenger()`
    - Fix playerInitiallyHasSpeedBoost is not the same
    - In GameLoading as challenger, skipped the `currentRoomId` set up