### PR TITLE
Commit 44: Handle enemy deleting Game document during GameOver  (6/17)

### DIFF
--- a/iOS/FuFight/FuFight/Game/GameView/GameView.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/GameView.swift
@@ -38,7 +38,11 @@ struct GameView: View {
         .alert(title: vm.player.isDead ? "You lost" : "You won!",
                primaryButton: AlertButton(title: "Rematch", action: vm.rematch),
                secondaryButton: AlertButton(title: "Go home", action: vm.exitGame),
-               isPresented: .constant(vm.state == .gameOver))
+               isPresented: .constant(vm.player.isDead || vm.enemy.isDead))
+        .alert(title: "You won!",
+               message: "Congrats! Enemy rage quitted",
+               primaryButton: AlertButton(title: "Go home", action: vm.exitGame),
+               isPresented: $vm.enemyExited)
         .alert(title: "Game is paused",
                primaryButton: AlertButton(title: "Resume", action: {}),
                secondaryButton: AlertButton(title: "Exit", action: vm.exitGame),

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/MainAlert.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/MainAlert.swift
@@ -120,9 +120,10 @@ struct MainAlert: View {
         HStack(spacing: 12) {
             if dismissButton != nil {
                 dismissButtonView
-
             } else if primaryButton != nil, secondaryButton != nil {
                 secondaryButtonView
+                primaryButtonView
+            } else if primaryButton != nil {
                 primaryButtonView
             }
         }

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/MainAlertModifier.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/MainAlertModifier.swift
@@ -64,6 +64,17 @@ extension MainAlertModifier {
         _text = .constant("")
     }
 
+    ///Initializer for primary button only alert
+    init(title: String = "", message: String = "", primaryButton: AlertButton, isPresented: Binding<Bool>) {
+        self.title         = title
+        self.message       = message
+        self.dismissButton = nil
+        self.primaryButton   = primaryButton
+        self.secondaryButton = nil
+        _isPresented = isPresented
+        _text = .constant("")
+    }
+
     ///Initializer for alerts with a TextField
     init(withText text: Binding<String>, fieldType: FieldType, title: String, primaryButton: AlertButton?, secondaryButton: AlertButton?, isPresented: Binding<Bool>) {
         self.fieldType = fieldType

--- a/iOS/FuFight/Helpers/Extensions/View+Extensions.swift
+++ b/iOS/FuFight/Helpers/Extensions/View+Extensions.swift
@@ -30,6 +30,13 @@ extension View {
         return modifier(MainAlertModifier(title: title, message: message, primaryButton: primaryButton, secondaryButton: secondaryButton, isPresented: isPresented))
     }
 
+    ///Present alert with a primary button only
+    func alert(title: String = "", message: String = "", primaryButton: AlertButton, isPresented: Binding<Bool>) -> some View {
+        let title   = NSLocalizedString(title, comment: "")
+        let message = NSLocalizedString(message, comment: "")
+        return modifier(MainAlertModifier(title: title, message: message, primaryButton: primaryButton, isPresented: isPresented))
+    }
+
     ///alerts with a TextField
     func alert(withText text: Binding<String>, fieldType: FieldType, title: String, primaryButton: AlertButton?, secondaryButton: AlertButton? = AlertButton(type: .cancel), isPresented: Binding<Bool>) -> some View {
         return modifier(MainAlertModifier(withText: text, fieldType: fieldType, title: title, primaryButton: primaryButton, secondaryButton: secondaryButton, isPresented: isPresented))


### PR DESCRIPTION
    - Updated MainAlert to have one button only as primary button
    - Updated MainAlert to have a go home AlertButton
    - Show alert with one primary button when enemy exits the game
        - When enemy leaves, show GameOver
    - Updated gameOver alert to show when one of the player dies only
    - These changes fixed the issue when enemy deletes their game document because their game is over, the player’s game is forcefully exited