### PR TITLE
Commit 49: Fix changing fighter does update the fighter shown (6/19- …

### DIFF
--- a/iOS/FuFight/FuFight/Game/GameView/Model/Fighter.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/Fighter.swift
@@ -10,7 +10,7 @@ import SceneKit
 ///3D model of the fighter
 class Fighter {
     //MARK: Properties
-    let fighterType: FighterType
+    var fighterType: FighterType
     let isEnemy: Bool
     private(set) var defaultAnimation: AnimationType
 
@@ -69,14 +69,18 @@ class Fighter {
         self.isEnemy = isEnemy
         defaultAnimation = .idle
         createNode()
-        playAnimation(defaultAnimation)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    //MARK: - Public Methods.
+    //MARK: - Public Methods
+    func switchFighter() {
+        let nextFighterType: FighterType = fighterType == .clara ? .samuel : .clara
+        fighterType = nextFighterType
+    }
+
     func positionNode(asHorizontal: Bool = false) {
         daeHolderNode.scale = SCNVector3Make(fighterType.scale, fighterType.scale, fighterType.scale)
         var xPosition: Float = isEnemy ? 1.5 : 0    //further

--- a/iOS/FuFight/FuFight/Home/DaePreview.swift
+++ b/iOS/FuFight/FuFight/Home/DaePreview.swift
@@ -10,23 +10,13 @@ import SceneKit
 
 /// A Preview of fighter
 struct DaePreview: UIViewRepresentable {
-    typealias UIViewType = SCNView
-
-    var fighterType: FighterType = .samuel
-    var animationType: AnimationType = .idle
     var scene: SCNScene
 
+    typealias UIViewType = SCNView
     private let cameraNode = SCNNode()
 
-    init(fighterType: FighterType, animationType: AnimationType) {
-        self.fighterType = fighterType
-        self.animationType = animationType
-        self.scene = SCNScene(named: fighterType.animationPath(.idle))!
-    }
-
-    init() {
-        self.fighterType = Room.current?.player.fighterType ?? .samuel
-        self.scene = SCNScene(named: fighterType.animationPath(.idle))!
+    init(scene: SCNScene) {
+        self.scene = scene
     }
 
     func makeUIView(context: Context) -> UIViewType {
@@ -40,8 +30,7 @@ struct DaePreview: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIViewType, context: Context) {
-        let path = fighterType.animationPath(animationType)
-        uiView.scene = SCNScene(named: path)
+        uiView.scene = scene
     }
 }
 
@@ -52,7 +41,7 @@ extension DaePreview {
 //        view.defaultCameraController.inertiaEnabled = true
 //        view.defaultCameraController.maximumVerticalAngle = 89
 //        view.defaultCameraController.minimumVerticalAngle = -89
-        
+
         // Using custom camera
         let camera = SCNCamera()
         camera.usesOrthographicProjection = true
@@ -64,6 +53,8 @@ extension DaePreview {
         cameraNode.camera = camera
         let cameraOrbit = SCNNode()
         cameraOrbit.addChildNode(cameraNode)
+//        cameraOrbit.eulerAngles.y = Float(-2 * M_PI) * widthRatio
+//        cameraOrbit.eulerAngles.x = Float(-M_PI) * heightRatio
         scene.rootNode.addChildNode(cameraOrbit)
     }
 }

--- a/iOS/FuFight/FuFight/Home/HomeView.swift
+++ b/iOS/FuFight/FuFight/Home/HomeView.swift
@@ -127,10 +127,8 @@ struct HomeView: View {
     }
 
     @ViewBuilder var fighterView: some View {
-        if vm.fighter != nil {
-            FighterView(vm.fighter)
-                .frame(maxWidth: .infinity)
-                .ignoresSafeArea(edges: .vertical)
+        if let fighter = vm.fighter {
+            DaePreview(scene: createFighterScene(fighterType: fighter.fighterType, animation: fighter.defaultAnimation))
         }
     }
 }

--- a/iOS/FuFight/FuFight/Room/RoomManager.swift
+++ b/iOS/FuFight/FuFight/Room/RoomManager.swift
@@ -73,7 +73,6 @@ class RoomManager {
 
     static func goOnlineIfNeeded() {
         guard let currentRoom = Room.current else { return }
-        LOGD("Room is going online from \(currentRoom.status)")
         switch currentRoom.status {
         case .online:
             break

--- a/iOS/FuFight/FuFight/Room/RoomView.swift
+++ b/iOS/FuFight/FuFight/Room/RoomView.swift
@@ -88,8 +88,8 @@ struct RoomView: View {
     }
 
     @ViewBuilder var fighterView: some View {
-        if vm.fighter != nil {
-            FighterView(vm.fighter)
+        if let fighterScene = vm.fighterScene {
+            DaePreview(scene: fighterScene)
         }
     }
 }

--- a/iOS/FuFight/FuFight/Room/RoomViewModel.swift
+++ b/iOS/FuFight/FuFight/Room/RoomViewModel.swift
@@ -7,13 +7,14 @@
 
 import Combine
 import SwiftUI
+import SceneKit
 
 final class RoomViewModel: BaseAccountViewModel {
-    @Published var player: FetchedPlayer!
-    @Published var fighter: Fighter!
+    var player: FetchedPlayer!
+    var fighter: Fighter!
+    var animationType: AnimationType = .idle
     @Published var path = NavigationPath()
-    @Published var animationType: AnimationType = .idle
-
+    @Published var fighterScene: SCNScene!
     let playerType: PlayerType = .user
 
     //MARK: - Override Methods
@@ -26,12 +27,12 @@ final class RoomViewModel: BaseAccountViewModel {
     func attackSelected(_ position: AttackPosition) {
         updateMove(position)
         let animation = player.moves.attacks.getAnimation(at: position)
-        fighter.playAnimation(animation)
+        updateAnimation(animation)
     }
 
     func defenseSelected(_ position: DefensePosition) {
         let animation = player.moves.defenses.getAnimation(at: position)
-        fighter.playAnimation(animation)
+        updateAnimation(animation)
     }
 
     func switchButtonSelected() {
@@ -46,22 +47,44 @@ private extension RoomViewModel {
     func refreshPlayer() {
         guard let player = RoomManager.getPlayer() else { return }
         self.player = player
-        self.fighter = Fighter(type: player.fighterType, isEnemy: false)
+        if let fighter = fighter {
+            if player.fighterType != fighter.fighterType {
+                fighter.switchFighter()
+                fighterScene = createFighterScene(fighterType: fighter.fighterType, animation: animationType)
+            }
+        } else {
+            self.fighter = Fighter(type: player.fighterType, isEnemy: false)
+            fighterScene = createFighterScene(fighterType: player.fighterType, animation: animationType)
+        }
     }
 
     func updatePlayer(with updatedPlayer: FetchedPlayer) {
         guard let currentRoom = Room.current else { return }
-        currentRoom.updatePlayer(player: player)
+        currentRoom.updatePlayer(player: updatedPlayer)
+        updateLoadingMessage(to: "")
         Task {
+            try await RoomManager.saveCurrent(currentRoom)
+            refreshPlayer()
             try await RoomNetworkManager.updateOwner(updatedPlayer)
+            updateLoadingMessage(to: nil)
         }
-        RoomManager.saveCurrent(currentRoom)
-        player = updatedPlayer
     }
 
     func updateMove(_ position: AttackPosition) {
         let tempPlayer = player!
         tempPlayer.moves.toggleType(at: position)
         updatePlayer(with: tempPlayer)
+    }
+
+    func updateAnimation(_ animation: AnimationType) {
+        //Play animation
+        animationType = animation
+        fighterScene = createFighterScene(fighterType: fighter.fighterType, animation: animationType)
+        //Go back to default animation after showing the animation
+        runAfterDelay(delay: animation.animationDuration(for: fighter.fighterType) - 0.2) { [weak self] in
+            guard let self else { return }
+            animationType = fighter.defaultAnimation
+            fighterScene = createFighterScene(fighterType: fighter.fighterType, animation: animationType)
+        }
     }
 }

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -10,6 +10,7 @@ import FirebaseCore
 import FirebaseFirestore
 import FirebaseStorage
 import SwiftUI
+import SceneKit
 
 //MARK: Firebase Auth constants
 let auth = Auth.auth()
@@ -150,4 +151,16 @@ func runAfterDelay(delay: TimeInterval, action: @escaping () -> Void) {
             action()
         }
     }
+}
+
+func createFighterScene(fighterType: FighterType, animation: AnimationType) -> SCNScene {
+    let path = fighterType.animationPath(animation)
+    let scene = SCNScene(named: path)!
+    scene.rootNode.enumerateChildNodes { (child, stop) in
+        if let partName = child.name,
+           let part = SkeletonType(rawValue: partName) {
+            child.geometry?.firstMaterial = part.material
+        }
+    }
+    return scene
 }


### PR DESCRIPTION
…6/20)

    - Issue: Previous commit did not handle when fighter is switched to a different fighter
    - In `Fighter`, add a way to switch `FighterType`
    - Replaced `FighterView` back to `DaePreview` which now only take a `SCNScene`
    - Created a way to create a SCNScene from FighterType and AnimationType