### PR TITLE
- Commit 27: Show TabBar’s overlayed view (7/6)

### DIFF
--- a/iOS/FuFight/FuFight/App/ContentView.swift
+++ b/iOS/FuFight/FuFight/App/ContentView.swift
@@ -46,6 +46,15 @@ enum Tab: String, CaseIterable, Identifiable {
             "party.popper"
         }
     }
+
+    var bottomViewHeight: CGFloat {
+        switch self {
+        case .store, .home, .school, .events:
+            homeBottomViewHeight
+        case .collections:
+            0
+        }
+    }
 }
 
 ///Root view that handles which view to show
@@ -79,14 +88,21 @@ struct ContentView: View {
                         Spacer()
 
                         if showTab {
-                            //MARK: - TabBar
-                            HStack(alignment: .bottom, spacing: 1) {
-                                ForEach(tabs, id: \.self) { currentTab in
-                                    tabBarItem(currentTab, reader: reader)
+                            VStack(spacing: 4) {
+                                Spacer()
+
+                                //TODO: Add FighterType and buttons overlay
+                                homeBottomView()
+
+                                //MARK: - TabBar
+                                HStack(alignment: .bottom, spacing: 1) {
+                                    ForEach(tabs, id: \.self) { currentTab in
+                                        tabBarItem(currentTab, reader: reader)
+                                    }
                                 }
+                                .transition(.move(edge: .bottom))
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
                             }
-                            .transition(.move(edge: .bottom))
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
                         }
                     }
                 }
@@ -104,6 +120,22 @@ struct ContentView: View {
                 createAuthenticationView(step: .logIn)
             }
         }
+    }
+
+    func homeBottomView() -> some View {
+        HStack {
+            Image(Room.current?.player.fighterType.headShotImageName ?? "")
+                .defaultImageModifier()
+
+            Spacer()
+        }
+        .background {
+            Color.clear
+        }
+        .frame(height: tab.bottomViewHeight)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, smallerHorizontalPadding)
+        .allowsHitTesting(false)
     }
 
 //    var characterDetailView: some View {

--- a/iOS/FuFight/FuFight/Room/CharacterListView.swift
+++ b/iOS/FuFight/FuFight/Room/CharacterListView.swift
@@ -9,11 +9,10 @@ import SwiftUI
 
 struct CharacterListView: View {
     @Binding var selectedFighterType: FighterType?
-    let itemSpacing: CGFloat = 2
-    let columns = Array(repeating: GridItem(.adaptive(minimum: 160), spacing: 2), count: 3)
+    let columns = Array(repeating: GridItem(.adaptive(minimum: 160), spacing: characterItemSpacing), count: 3)
 
     var body: some View {
-        LazyVGrid(columns: columns, spacing: itemSpacing) {
+        LazyVGrid(columns: columns, spacing: characterItemSpacing) {
             ForEach(characters, id: \.self) { character in
                 CharacterObjectCell(character: character, isSelected: character.id == selectedFighterType?.id) {
                     LOGD("CHARACTER SELECTED \(character.fighterType.name)")
@@ -21,7 +20,6 @@ struct CharacterListView: View {
                 }
             }
         }
-        .padding()
     }
 }
 
@@ -29,8 +27,6 @@ struct CharacterObjectCell: View {
     var character: CharacterObject
     var isSelected: Bool
     var action: () -> Void
-
-    private let borderWidth: CGFloat = 5
 
     init(character: CharacterObject, isSelected: Bool, action: @escaping () -> Void) {
         UITableViewCell.appearance().backgroundColor = .clear
@@ -87,8 +83,8 @@ struct CharacterObjectCell: View {
                     .padding(.bottom, 4)
             }
             .background(Color.black)
-            .padding(borderWidth)
-            .border(.yellow, width: isSelected ? borderWidth : 0)
+            .padding(characterItemBorderWidth)
+            .border(.yellow, width: isSelected ? characterItemBorderWidth : 0)
             .minimumScaleFactor(0.3)
             .lineLimit(1)
         })

--- a/iOS/FuFight/FuFight/Room/RoomView.swift
+++ b/iOS/FuFight/FuFight/Room/RoomView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct RoomView: View {
     @StateObject var vm: RoomViewModel
-    
+
+    private let bottomOffsetPadding: CGFloat = 24
+
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             ScrollViewReader { value in
@@ -21,16 +23,21 @@ struct RoomView: View {
 
                         VStack {
                             CharacterListView(selectedFighterType: $vm.selectedFighterType)
+                                .padding(.horizontal, smallerHorizontalPadding)
                         }
+                        .padding(.bottom, homeBottomViewHeight)
                     }
                     .alert(title: vm.alertTitle, message: vm.alertMessage, isPresented: $vm.isAlertPresented)
                     .padding(.top, UserDefaults.topSafeAreaInset + 6)
-                    .padding(.bottom, UserDefaults.bottomSafeAreaInset + 50)
+                    .padding(.bottom, UserDefaults.bottomSafeAreaInset - charactersBottomButtonsHeight + bottomOffsetPadding)
                 }
             }
         }
         .overlay {
             LoadingView(message: vm.loadingMessage)
+        }
+        .overlay {
+            bottomButtonsView
         }
         .navigationBarHidden(true)
         .frame(maxWidth: .infinity)
@@ -64,6 +71,21 @@ struct RoomView: View {
             }
         }
         .padding(.horizontal, smallerHorizontalPadding)
+    }
+
+    var bottomButtonsView: some View {
+        VStack {
+            Spacer()
+
+            Color.white
+                .padding(.horizontal, smallerHorizontalPadding)
+                .frame(height: charactersBottomButtonsHeight)
+                .frame(maxWidth: .infinity)
+
+            Spacer()
+                .frame(height: UserDefaults.bottomSafeAreaInset + charactersBottomButtonsHeight + bottomOffsetPadding)
+        }
+        .allowsHitTesting(false)
     }
 }
 

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -39,6 +39,10 @@ let defaultMaxTime: Int = 5
 let defaultMaxHp: CGFloat = 100
 let defaultEnemyHp: CGFloat = 100
 let fighterCellSize: CGFloat = 80
+let characterItemSpacing: CGFloat = 2
+let characterItemBorderWidth: CGFloat = 5
+let homeBottomViewHeight: CGFloat = 120
+let charactersBottomButtonsHeight: CGFloat = 40
 
 var animationToTest: AnimationType = .punchHeadRightHard
 


### PR DESCRIPTION
    - Add a bottomView on top of the tab bar
        - Show the bottom view for all tabs except for Collections tab
        - Show selected fighter’s headshot image
    - For Collections Tab, hide bottomView and add a custom bottomView inside RoomView