### PR TITLE
Commit 43: Improved UI when switching GameType (7/15)

### DIFF
--- a/iOS/FuFight/FuFight/Home/GameType.swift
+++ b/iOS/FuFight/FuFight/Home/GameType.swift
@@ -8,10 +8,21 @@
 import SwiftUI
 
 //MARK: - GameType
-enum GameType: String, CaseIterable, Hashable, Identifiable {
+enum GameType: String, CaseIterable {
     case offline
     case casual
     case rank
+
+    var title: String {
+        switch self {
+        case .offline:
+            "Offline"
+        case .casual:
+            "Casual"
+        case .rank:
+            "Rank"
+        }
+    }
 
     var color: Color? {
         switch self {
@@ -32,7 +43,9 @@ enum GameType: String, CaseIterable, Hashable, Identifiable {
             true
         }
     }
+}
 
+extension GameType: Hashable, Identifiable {
     var id: String { rawValue }
 
     static func == (lhs: GameType, rhs: GameType) -> Bool {

--- a/iOS/FuFight/FuFight/Home/HomeViewModel.swift
+++ b/iOS/FuFight/FuFight/Home/HomeViewModel.swift
@@ -14,7 +14,7 @@ final class HomeViewModel: BaseAccountViewModel {
     @Published var isAccountVerified = false
     @Published var path = NavigationPath()
     @Published var selectedGameType: GameType = .casual
-    @Published var showButtons: Bool = true
+    @Published var isOffline: Bool = false
 
     let gameTypes: [GameType] = GameType.allCases
     let availableButtonTypes: [HomeButtonType] = HomeButtonType.allCases
@@ -37,6 +37,14 @@ final class HomeViewModel: BaseAccountViewModel {
     }
 
     //MARK: - Public Methods
+    func gameTypeUpdatedHandler() {
+        withAnimation {
+            isOffline = !selectedGameType.requiresWifi
+        }
+    }
+}
+
+private extension HomeViewModel {
     ///Make sure account is valid at least once
     @MainActor func verifyAccount() {
         if !isAccountVerified {


### PR DESCRIPTION
    - Renamed `showButtons` to `isOffline` and sets it to true when GameType is offline
    - Update HomeView’s play buttons
        - Show 1 play button only for casual and rank GameType
        - Show practice and offline buttons for offline GameType
    - Hide FriendList view when in offline GameType
    - Show a label and to differentiate between each GameType