### PR TITLE
Commit 48: Add a way to show Account from Profile pic tap (7/15)

### DIFF
--- a/iOS/FuFight/FuFight/Account/AccountView.swift
+++ b/iOS/FuFight/FuFight/Account/AccountView.swift
@@ -13,8 +13,6 @@ struct AccountView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                navigationView
-
                 VStack(spacing: 12) {
                     profilePicture
 
@@ -64,13 +62,26 @@ struct AccountView: View {
             hideKeyboard()
         }
         .navigationBarHidden(true)
+        .safeAreaInset(edge: .bottom) {
+            navigationView
+        }
     }
 
+    var backButton: some View {
+        Button(action: {
+            vm.didBack.send(vm)
+        }) {
+            Text("Back")
+                .padding(.vertical, 4)
+        }
+        .appButton(.destructive, hasPadding: true)
+    }
     var editSaveButton: some View {
         Button(action: vm.editSaveButtonTapped) {
             Text(vm.isViewingMode ? Str.editTitle : Str.saveTitle)
+                .padding(.vertical, 4)
         }
-        .appButton(.tertiary, hasPadding: false)
+        .appButton(.tertiary, hasPadding: true)
     }
     var profilePicture: some View {
         AccountImagePicker(selectedImage: $vm.selectedImage, url: $vm.account.photoUrl)
@@ -101,38 +112,36 @@ struct AccountView: View {
             vm.changePasswordButtonTapped()
         } label: {
             Text(Str.changePasswordTitle)
-                .frame(maxWidth: .infinity)
+                .frame(height: 50)
         }
-        .appButton(.primary)
+        .appButton(.secondary)
     }
     var deleteAccountButton: some View {
         Button(action: vm.deleteButtonTapped) {
             Text(Str.deleteTitle)
-                .frame(maxWidth: .infinity)
+                .frame(height: 50)
         }
         .appButton(.destructive)
     }
     var logOutButton: some View {
         Button(action: vm.logOut) {
             Text(Str.logOutTitle)
-                .frame(maxWidth: .infinity)
+                .frame(height: 50)
         }
         .appButton(.destructive, isBordered: true)
     }
     var navigationView: some View {
         HStack(alignment: .center) {
-            Button(action: {
-                vm.didBack.send(vm)
-            }, label: {
-                backButtonImage
-                    .padding(.leading, smallerHorizontalPadding)
-                    .frame(width: 104, height: 30)
-            })
+            backButton
+                .padding(.leading, 28)
 
             Spacer()
 
             editSaveButton
+                .padding(.trailing, 28)
         }
+        .padding(.bottom, UserDefaults.bottomSafeAreaInset)
+        .padding(.horizontal, smallerHorizontalPadding)
     }
 }
 

--- a/iOS/FuFight/FuFight/App/ContentView.swift
+++ b/iOS/FuFight/FuFight/App/ContentView.swift
@@ -77,9 +77,7 @@ struct ContentView: View {
                 .tabViewStyle(.page(indexDisplayMode: .never)) //adds swipe gesture and sliding effect when switching between tabs
                 .overlay {
                     VStack {
-                        if showNav {
-                            NavBar()
-                        }
+                        navBarView()
 
                         Spacer()
 
@@ -114,6 +112,16 @@ struct ContentView: View {
             case .loggedOut:
                 //Log in
                 createAuthenticationView(step: .logIn)
+            }
+        }
+    }
+
+    @ViewBuilder func navBarView() -> some View {
+        if showNav {
+            NavBar {
+                //TODO: Change this to one of the HomeButtonType
+                homeRouter.transitionToAccount(vm: homeRouter.makeHomeViewModel(account: account))
+                showNav = false
             }
         }
     }
@@ -214,7 +222,8 @@ struct ContentView: View {
             withAnimation(.easeInOut(duration: 0.2)) {
                 self.showTab = newValue.isEmpty
                 let isShowingGame = newValue.compactMap { $0.id }.contains("game")
-                self.showNav = !isShowingGame
+                let isShowingAccount = newValue.compactMap { $0.id }.contains("account")
+                self.showNav = !isShowingGame && !isShowingAccount
             }
         }
         .onAppear {

--- a/iOS/FuFight/FuFight/App/Navigation/NavBar.swift
+++ b/iOS/FuFight/FuFight/App/Navigation/NavBar.swift
@@ -9,12 +9,16 @@ import SwiftUI
 
 struct NavBar: View {
 
+    var usernameViewTap: (() -> Void)?
+
     var body: some View {
         VStack {
             statusBarView
 
             HStack {
-                UsernameView(photoUrl: Room.current?.player.photoUrl)
+                UsernameView(photoUrl: Room.current?.player.photoUrl) {
+                    usernameViewTap?()
+                }
 
                 Spacer()
 

--- a/iOS/FuFight/FuFight/App/Navigation/UsernameView.swift
+++ b/iOS/FuFight/FuFight/App/Navigation/UsernameView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct UsernameView: View {
     let photoUrl: URL?
+    let onImageTap: (() -> Void)?
     private let imageHeight: CGFloat = 38
 
     var body: some View {
@@ -27,6 +28,7 @@ struct UsernameView: View {
     var userImage: some View {
         Button {
             TODO("Go to user's profile")
+            onImageTap?()
         } label: {
             accountBackgroundImage
                 .overlay {
@@ -53,7 +55,7 @@ struct UsernameView: View {
 }
 
 #Preview {
-    UsernameView(photoUrl: fakePhotoUrl)
+    UsernameView(photoUrl: fakePhotoUrl, onImageTap: nil)
         .frame(height: 100)
         .background { Color.black }
 }

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -110,6 +110,10 @@ let plusButtonImage: some View = Image("plusButton").defaultImageModifier()
 let restartButtonImage: some View = Image("restartButton").buttonImageModifier()
 let resumeButtonImage: some View = Image("resumeButton").buttonImageModifier()
 let yesButtonButtonImage: some View = Image("yesButton").buttonImageModifier()
+let blueButtonImage: some View = Image("blueButton").buttonImageModifier()
+let greenButtonImage: some View = Image("greenButton").buttonImageModifier()
+let redButtonImage: some View = Image("redButton").buttonImageModifier()
+let yellowButtonImage: some View = Image("yellowButton").buttonImageModifier()
 
 //Icons
 let coinImage: some View = Image("coin").defaultImageModifier()

--- a/iOS/FuFight/Helpers/ViewModifiers/AppButtonModifier.swift
+++ b/iOS/FuFight/Helpers/ViewModifiers/AppButtonModifier.swift
@@ -50,27 +50,41 @@ struct AppButtonModifier: ViewModifier {
         content
             .font(buttonFont)
             .padding(.vertical, hasPadding ? 8 : 0)
-            .padding(.horizontal)
+            .padding(.horizontal, hasPadding ? 8 : 0)
             .background(background)
-            .foregroundColor(
-                Color(uiColor: foregroundColor))
-            .cornerRadius(24)
-            .overlay(
-                RoundedRectangle(cornerRadius: 24)
-                    .stroke(
-                        Color(uiColor: isEnabled ? viewType.color : disabledColor),
-                        lineWidth: 2)
-            )
+            .foregroundColor(Color(uiColor: foregroundColor))
+        //TODO: Figure out if needed. Previous implementation before images
+//            .cornerRadius(24)
+//            .overlay(
+//                RoundedRectangle(cornerRadius: 24)
+//                    .stroke(
+//                        Color(uiColor: isEnabled ? viewType.color : disabledColor),
+//                        lineWidth: 2)
+//            )
             .opacity(isEnabled ? 1 : 0.8)
     }
 
     var background: some View {
         Group {
-            if isEnabled {
-                Color(uiColor: isBordered ? .white : viewType.color)
-            } else {
-                Color(uiColor: isBordered ? .clear : disabledColor)
+            switch viewType {
+            case .primary:
+                yellowButtonImage
+            case .secondary:
+                blueButtonImage
+            case .tertiary:
+                yellowButtonImage
+            case .system:
+                greenButtonImage
+            case .destructive:
+                redButtonImage
             }
+
+            //TODO: Figure out if needed. Previous implementation before images
+//            if isEnabled {
+//                Color(uiColor: isBordered ? .white : viewType.color)
+//            } else {
+//                Color(uiColor: isBordered ? .clear : disabledColor)
+//            }
         }
     }
     var foregroundColor: UIColor {


### PR DESCRIPTION
    - Add a way to transition to `AccountView` when tapping on `UsernameView`
    - Hide nav bar when showing `AccountView`
    - Put back and edit buttons at the bottom
    - Updated AppButtonModifier to use the assets from Images as a background
    - Updated AccountView’s buttons