### PR TITLE
- Commit 49: Create `GameAlert` and `GameButton` (7/16)

### DIFF
--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -97,7 +97,9 @@ let navBarBackgroundImage: some View = Image("navBarBackground").navBarBackgroun
 let cityBackgroundImage: some View = Image("cityBackground").defaultImageModifier()
 let timerBackgroundImage: some View = Image("timerBackground").defaultImageModifier()
 let navBarContainerImage: some View = Image("navBarContainer").containerImageModifier()
-let yellowRingImage: some View = Image("yellowRing").containerImageModifier()
+let alertBodyBackgroundImage: some View = Image("alertBodyBackground").containerImageModifier()
+let alertTitleBackgroundImage_Shadowed: some View = Image("alertTitleBackground-shadowed").containerImageModifier()
+let alertTitleBackgroundImage: some View = Image("alertTitleBackground").containerImageModifier()
 
 //Buttons Folder
 let backButtonImage: some View = Image("backButton").buttonImageModifier()
@@ -118,6 +120,7 @@ let yellowButtonImage: some View = Image("yellowButton").buttonImageModifier()
 //Icons
 let coinImage: some View = Image("coin").defaultImageModifier()
 let diamondImage: some View = Image("diamond").defaultImageModifier()
+let yellowRingImage: some View = Image("yellowRing").containerImageModifier()
 
 //System Images
 let defaultProfilePhoto: UIImage = UIImage(systemName: "person.crop.circle")!

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/GameAlert.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/GameAlert.swift
@@ -1,0 +1,320 @@
+//
+//  GameAlert.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 7/16/24.
+//
+
+import Foundation
+
+import SwiftUI
+
+struct GameAlert: View {
+
+    // MARK: - Value
+    // MARK: Public
+    let title: String
+    let message: String
+    let dismissButton: GameButton?
+    let primaryButton: GameButton?
+    let secondaryButton: GameButton?
+    ///Show a TextField if this is not nil
+//    let fieldType: FieldType?
+//    @Binding var text: String
+//    @State var isFieldSecure: Bool = false
+
+    // MARK: Private
+    @State private var opacity: CGFloat           = 0
+    @State private var backgroundOpacity: CGFloat = 0
+    @State private var scale: CGFloat             = 0.001
+    private let alertWidth: CGFloat = 320
+    private let verticalPadding: CGFloat = 4
+    private let horizontalPadding: CGFloat = 12
+    private var isManyText: Bool {
+        message.count > 120
+    }
+
+    @Environment(\.dismiss) private var dismiss
+
+    ///Default initializer
+    init(title: String, message: String, dismissButton: GameButton?, primaryButton: GameButton?, secondaryButton: GameButton?) {
+        self.title = title
+        self.message = message
+        self.dismissButton = dismissButton
+        self.primaryButton = primaryButton
+        self.secondaryButton = secondaryButton
+//        fieldType = nil
+//        _text = .constant("")
+    }
+
+    ///Initializer for alerts with a TextField
+    init(withText text: Binding<String>, fieldType: FieldType, title: String, primaryButton: GameButton?, secondaryButton: GameButton?) {
+//        self.fieldType = fieldType
+        self.title = title
+        self.primaryButton = primaryButton
+        self.secondaryButton = secondaryButton
+//        _text = text
+        self.message = ""
+        self.dismissButton = nil
+    }
+
+    // MARK: - View
+    // MARK: Public
+    var body: some View {
+        GeometryReader { reader in
+            ZStack {
+                dimView
+
+                alertView(reader)
+            }
+            .ignoresSafeArea()
+            .transition(.opacity)
+            .task {
+                animate(isShown: true)
+            }
+        }
+//        .onAppear {
+//            if let fieldType {
+//                isFieldSecure = fieldType.isSensitive
+//            }
+//        }
+    }
+
+    // MARK: Private
+    @ViewBuilder func alertView(_ reader: GeometryProxy) -> some View {
+        VStack(spacing: 0) {
+            alertTitleBackgroundImage
+                .overlay {
+                    titleView
+                        .padding(.horizontal, horizontalPadding)
+                        .padding(.vertical, verticalPadding)
+                }
+
+            alertBodyBackgroundImage
+                .overlay {
+                    VStack(spacing: 0) {
+                        messageView
+                            .padding(.horizontal, horizontalPadding)
+
+                        if !isManyText {
+                            Spacer()
+                        }
+
+                        buttonsView(reader)
+                    }
+                    .padding(.top, verticalPadding * 2.5)
+                }
+        }
+        .padding([.horizontal], 24)
+        .padding(.bottom, verticalPadding)
+        .frame(width: alertWidth)
+        .frame(maxHeight: .infinity)
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.4), radius: 16, x: 0, y: 12)
+        .scaleEffect(scale)
+        .opacity(opacity)
+    }
+
+    @ViewBuilder
+    private var titleView: some View {
+        if !title.isEmpty {
+            Text(title)
+                .font(smallTitleFont)
+                .foregroundColor(Color.white)
+//                .lineSpacing(24 - UIFont.systemFont(ofSize: 18, weight: .bold).lineHeight)
+                .multilineTextAlignment(.center)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+    }
+
+    @ViewBuilder private var messageView: some View {
+//        if let fieldType {
+//            UnderlinedTextField(type: .constant(fieldType), text: $text, isSecure: $isFieldSecure, showTitle: false)
+//                .onSubmit {
+//                    primaryButtonAction()
+//                }
+//        } else
+        if !message.isEmpty {
+            if isManyText {
+                ScrollView(.vertical, showsIndicators: false) {
+                    messageLabel
+                }
+            } else {
+                messageLabel
+            }
+        }
+    }
+
+    @ViewBuilder private var messageLabel: some View {
+        Text(message)
+            .font(textFont)
+            .foregroundColor(Color.white)
+        //            .lineSpacing(24 - UIFont.systemFont(ofSize: title.isEmpty ? 18 : 16).lineHeight)
+            .multilineTextAlignment(.center)
+            .minimumScaleFactor(0.3)
+    }
+
+    func buttonsView(_ reader: GeometryProxy) -> some View {
+        HStack(spacing: 16) {
+            let buttonMultiplier: CGFloat = 0.3
+            if dismissButton != nil {
+                dismissButtonView
+                    .frame(width: reader.size.width * buttonMultiplier)
+            } else if primaryButton != nil, secondaryButton != nil {
+                secondaryButtonView
+                    .frame(width: reader.size.width * buttonMultiplier)
+
+                primaryButtonView
+                    .frame(width: reader.size.width * buttonMultiplier)
+            } else if primaryButton != nil {
+                primaryButtonView
+                    .frame(width: reader.size.width * buttonMultiplier)
+            }
+        }
+        .padding(.horizontal, horizontalPadding)
+    }
+
+    func primaryButtonAction() {
+        if let primaryButton {
+            animate(isShown: false) {
+                dismiss()
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                primaryButton.action?()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var primaryButtonView: some View {
+        if let primaryButton {
+            if primaryButton.type == .custom {
+                GameButton(title: primaryButton.title, action: primaryButtonAction)
+            } else {
+                GameButton(type: primaryButton.type, action: primaryButtonAction)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var secondaryButtonView: some View {
+        if let button = secondaryButton {
+            let buttonAction = {
+                animate(isShown: false) {
+                    dismiss()
+                }
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    button.action?()
+                }
+            }
+            if button.type == .custom {
+                GameButton(title: button.title, action: buttonAction)
+            } else {
+                GameButton(type: button.type, action: buttonAction)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dismissButtonView: some View {
+        if let button = dismissButton {
+            let buttonAction = {
+                animate(isShown: false) {
+                    dismiss()
+                }
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    button.action?()
+                }
+            }
+            if button.type == .custom {
+                GameButton(title: button.title, action: buttonAction)
+            } else {
+                GameButton(type: button.type, action: buttonAction)
+            }
+        }
+    }
+
+    private var dimView: some View {
+        Color.systemGray
+            .opacity(0.55)
+            .opacity(backgroundOpacity)
+            .onTapGesture {
+                animate(isShown: false) {
+                    dismiss()
+                }
+            }
+    }
+
+
+    // MARK: - Function
+    // MARK: Private
+    private func animate(isShown: Bool, completion: (() -> Void)? = nil) {
+        switch isShown {
+        case true:
+            opacity = 1
+
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.9, blendDuration: 0).delay(0.5)) {
+                backgroundOpacity = 1
+                scale             = 1
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                completion?()
+            }
+
+        case false:
+            withAnimation(.easeOut(duration: 0.2)) {
+                backgroundOpacity = 0
+                opacity           = 0
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                completion?()
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct GameAlert_Previews: PreviewProvider {
+
+    static var previews: some View {
+        let showType: Bool = true
+
+        let dismissButton   = GameButton(title: "Ok")
+        let primaryButton   = GameButton(title: "Ok")
+        let secondaryButton = GameButton(title: "Cancel")
+
+        let dismissButton2   = GameButton(type: .ok)
+        let primaryButton2   = GameButton(type: .delete)
+        let secondaryButton2 = GameButton(type: .ok)
+
+        let title = "Error connecting game to the server"
+        let message = """
+                    If you don't like something, change it again and again.
+                    If you don't like your job, quit.
+                    If you don't have enough time, stop watching TV.
+                    If you don't have enough time, stop watching TV.
+                    """
+        let message2 = """
+                    If you don't like something, change it again and again. If you don't like your job, quit.
+                    """
+
+        return VStack {
+            if showType {
+                GameAlert(title: title, message: message, dismissButton: dismissButton2, primaryButton: nil,            secondaryButton: nil)
+                GameAlert(title: title, message: message2, dismissButton: nil,           primaryButton: primaryButton2, secondaryButton: secondaryButton2)
+            } else {
+                GameAlert(title: title, message: message, dismissButton: nil,           primaryButton: nil,           secondaryButton: nil)
+                GameAlert(title: title, message: message2, dismissButton: dismissButton, primaryButton: nil,          secondaryButton: nil)
+                GameAlert(title: title, message: message, dismissButton: nil,           primaryButton: primaryButton, secondaryButton: secondaryButton)
+            }
+        }
+        .previewDevice("iPhone 13 Pro Max")
+        .preferredColorScheme(.light)
+    }
+}
+#endif

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/GameButton.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/GameButton.swift
@@ -1,0 +1,132 @@
+//
+//  GameButton.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 7/16/24.
+//
+
+import SwiftUI
+
+enum GameButtonType {
+    case cancel, secondaryCancel, ok, secondaryOk, custom, delete, dismiss
+
+    var title: String {
+        switch self {
+        case .cancel, .secondaryCancel:
+            "Cancel"
+        case .delete:
+            "Delete"
+        case .ok, .secondaryOk:
+            "Ok"
+        case .custom:
+            ""
+        case .dismiss:
+            "Dismiss"
+        }
+    }
+
+    @ViewBuilder var background: some View {
+        switch self {
+        case .cancel:
+            yellowButtonImage
+        case .secondaryCancel:
+            blueButtonImage
+        case .ok:
+            yellowButtonImage
+        case .secondaryOk:
+            greenButtonImage
+        case .custom:
+            yellowButtonImage
+        case .delete:
+            redButtonImage
+        case .dismiss:
+            yellowButtonImage
+        }
+    }
+
+    var bgColor: UIColor {
+        switch self {
+        case .cancel, .secondaryCancel:
+            backgroundUiColor
+        case .delete:
+            destructiveUiColor
+        case .ok, .secondaryOk:
+            backgroundUiColor
+        case .custom:
+            backgroundUiColor
+        case .dismiss:
+            backgroundUiColor
+        }
+    }
+
+    var textColor: UIColor {
+        .white
+    }
+}
+
+struct GameButton: View {
+    // MARK: Public
+    var type: GameButtonType
+    let title: String
+    let textColor: UIColor
+    let bgColor: UIColor
+    var action: (() -> Void)? = nil
+    private let cornerRadius: CGFloat = 25
+
+    init(title: String, textColor: UIColor = .systemBackground, bgColor: UIColor = .systemBackground, action: (() -> Void)? = nil) {
+        self.title = title
+        self.textColor = textColor
+        self.bgColor = bgColor
+        self.action = action
+        self.type = .custom
+    }
+
+    init(type: GameButtonType, action: (() -> Void)? = nil) {
+        self.type = type
+        self.title = type.title
+        self.textColor = type.textColor
+        self.bgColor = type.bgColor
+        self.action = action
+    }
+
+    // MARK: - View
+    // MARK: Public
+    var body: some View {
+        Button {
+            action?()
+        } label: {
+            Text(title)
+                .font(mediumTextFont)
+                .foregroundColor(Color(uiColor: textColor))
+                .frame(maxWidth: .infinity, maxHeight: 45)
+        }
+        .background(
+            type.background
+        )
+    }
+}
+
+struct GameButton_Previews: PreviewProvider {
+
+    static var previews: some View {
+        let dismissButton   = GameButton(title: "Ok")
+        let primaryButton   = GameButton(title: "Ok")
+        let secondaryButton = GameButton(title: "Cancel")
+
+        let dismissButton2   = GameButton(type: .cancel)
+        let primaryButton2   = GameButton(type: .delete)
+        let secondaryButton2 = GameButton(type: .ok)
+
+        return VStack(spacing: 100) {
+            dismissButton
+            primaryButton
+            secondaryButton
+
+            dismissButton2
+            primaryButton2
+            secondaryButton2
+        }
+        .padding(.horizontal, 50)
+        .preferredColorScheme(.dark)
+    }
+}


### PR DESCRIPTION
    - Create `GameButton` similar to `AlertButton` and using the actual game button asset as the background
    - Create `GameAlert` and using the assets as the titleBar and body background
        - Added reference to alert background assets from Images
        - Showed GameButton in GameAlert
    - Fixed accessibility to look good with despite amount of text
        - Put message in a scrollView if it has a lot of characters