### PR TITLE
- Commit 52: Fix UpdatePasswordView’s buttons (7/16)

### DIFF
--- a/iOS/FuFight/FuFight/Account/AccountView.swift
+++ b/iOS/FuFight/FuFight/Account/AccountView.swift
@@ -72,12 +72,12 @@ struct AccountView: View {
     }
 
     var backButton: some View {
-        GameButton(title: "Back", type: .delete) {
+        GameButton(title: "Back", type: .delete, maxWidth: navBarButtonMaxWidth) {
             vm.didBack.send(vm)
         }
     }
     var editSaveButton: some View {
-        GameButton(title: vm.isViewingMode ? Str.editTitle : Str.saveTitle, type: .custom, action: vm.editSaveButtonTapped)
+        GameButton(title: vm.isViewingMode ? Str.editTitle : Str.saveTitle, type: .custom, maxWidth: navBarButtonMaxWidth, action: vm.editSaveButtonTapped)
     }
     var profilePicture: some View {
         AccountImagePicker(selectedImage: $vm.selectedImage, url: $vm.account.photoUrl)
@@ -126,6 +126,7 @@ struct AccountView: View {
 
             editSaveButton
         }
+        .fixedSize(horizontal: false, vertical: true)
         .padding(.bottom, UserDefaults.bottomSafeAreaInset)
         .padding(.horizontal, smallerHorizontalPadding)
     }

--- a/iOS/FuFight/FuFight/Account/UpdatePassword/UpdatePasswordView.swift
+++ b/iOS/FuFight/FuFight/Account/UpdatePassword/UpdatePasswordView.swift
@@ -13,33 +13,28 @@ struct UpdatePasswordView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 0) {
-                navigationView
+            GeometryReader { reader in
+                VStack(spacing: 0) {
+                    VStack(spacing: 12) {
+                        currentPasswordField
 
-                VStack(spacing: 12) {
-                    currentPasswordField
+                        passwordField
 
-                    passwordField
+                        confirmPasswordField
 
-                    confirmPasswordField
+                        Spacer()
 
-                    Spacer()
+                        updatePasswordButton(reader)
+                    }
+                    .padding(.horizontal, horizontalPadding)
                 }
-                .padding(.horizontal, horizontalPadding)
+                .alert(title: vm.alertTitle, message: vm.alertMessage, isPresented: $vm.isAlertPresented)
+                .padding(.top, homeNavBarHeight + 6)
+                .padding(.bottom, UserDefaults.bottomSafeAreaInset + 6)
             }
-            .alert(title: vm.alertTitle, message: vm.alertMessage, isPresented: $vm.isAlertPresented)
-            .padding(.top, homeNavBarHeight + 6)
-            .padding(.bottom, UserDefaults.bottomSafeAreaInset + 6)
         }
         .overlay {
             LoadingView(message: vm.loadingMessage)
-        }
-        .overlay {
-            VStack {
-                Spacer()
-
-                updatePasswordButton
-            }
         }
         .onAppear {
             vm.onAppear()
@@ -55,6 +50,9 @@ struct UpdatePasswordView: View {
             AnimatingBackgroundView(animate: true, leadingPadding: -900)
         }
         .navigationBarHidden(true)
+        .safeAreaInset(edge: .bottom) {
+            navigationView
+        }
     }
 
     var currentPasswordField: some View {
@@ -93,28 +91,23 @@ struct UpdatePasswordView: View {
             vm.updatePasswordButtonTapped()
         }
     }
-    var updatePasswordButton: some View {
-        Button(action: vm.updatePasswordButtonTapped) {
-            Text(Str.updatePasswordTitle)
-                .frame(maxWidth: .infinity)
+    var backButton: some View {
+        GameButton(title: "Back", type: .delete, maxWidth: navBarButtonMaxWidth) {
+            vm.didBack.send(vm)
         }
-        .appButton(.primary)
-        .disabled(!vm.isUpdatePasswordButtonEnabled)
-        .padding(.horizontal, horizontalPadding)
-        .padding(.bottom, UserDefaults.bottomSafeAreaInset + 6)
+    }
+    @ViewBuilder private func updatePasswordButton(_ reader: GeometryProxy) -> some View {
+        GameButton(title: Str.updatePasswordTitle, maxWidth: reader.size.width * 0.4, action: vm.updatePasswordButtonTapped)
     }
     var navigationView: some View {
         HStack(alignment: .center) {
-            Button(action: {
-                vm.didBack.send(vm)
-            }, label: {
-                backButtonImage
-                    .padding(.leading, smallerHorizontalPadding)
-                    .frame(width: 104, height: 30)
-            })
+            backButton
 
             Spacer()
         }
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.bottom, UserDefaults.bottomSafeAreaInset)
+        .padding(.horizontal, smallerHorizontalPadding)
     }
 }
 

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -47,6 +47,7 @@ let homeBottomViewHeight: CGFloat = 120
 let charactersBottomButtonsHeight: CGFloat = 40
 let homeNavBarHeight: CGFloat = 120
 let navBarIconSize: CGFloat = 25
+let navBarButtonMaxWidth: CGFloat = 50
 
 var animationToTest: AnimationType = .punchHeadRightHard
 

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/GameAlert.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/GameAlert.swift
@@ -30,6 +30,7 @@ struct GameAlert: View {
     private let alertWidth: CGFloat = 360
     private let verticalPadding: CGFloat = 4
     private let horizontalPadding: CGFloat = 12
+    private let buttonMultiplier: CGFloat = 0.3
     private var isManyText: Bool {
         message.count > 120
     }
@@ -157,22 +158,18 @@ struct GameAlert: View {
 
     func buttonsView(_ reader: GeometryProxy) -> some View {
         HStack(spacing: 16) {
-            let buttonMultiplier: CGFloat = 0.3
             if dismissButton != nil {
-                dismissButtonView
-                    .frame(width: reader.size.width * buttonMultiplier)
+                dismissButtonView(reader)
             } else if primaryButton != nil, secondaryButton != nil {
-                secondaryButtonView
-                    .frame(width: reader.size.width * buttonMultiplier)
+                secondaryButtonView(reader)
 
-                primaryButtonView
-                    .frame(width: reader.size.width * buttonMultiplier)
+                primaryButtonView(reader)
             } else if primaryButton != nil {
-                primaryButtonView
-                    .frame(width: reader.size.width * buttonMultiplier)
+                primaryButtonView(reader)
             }
         }
         .padding(.horizontal, horizontalPadding)
+        .padding(.bottom)
     }
 
     func primaryButtonAction() {
@@ -186,19 +183,17 @@ struct GameAlert: View {
         }
     }
 
-    @ViewBuilder
-    private var primaryButtonView: some View {
+    @ViewBuilder private func primaryButtonView(_ reader: GeometryProxy) -> some View {
         if let primaryButton {
             if primaryButton.type == .custom {
-                GameButton(title: primaryButton.title, action: primaryButtonAction)
+                GameButton(title: primaryButton.title, maxWidth: reader.size.width * buttonMultiplier, action: primaryButtonAction)
             } else {
-                GameButton(type: primaryButton.type, action: primaryButtonAction)
+                GameButton(type: primaryButton.type, maxWidth: reader.size.width * buttonMultiplier, action: primaryButtonAction)
             }
         }
     }
 
-    @ViewBuilder
-    private var secondaryButtonView: some View {
+    @ViewBuilder private func secondaryButtonView(_ reader: GeometryProxy) -> some View {
         if let button = secondaryButton {
             let buttonAction = {
                 animate(isShown: false) {
@@ -210,15 +205,14 @@ struct GameAlert: View {
                 }
             }
             if button.type == .custom {
-                GameButton(title: button.title, action: buttonAction)
+                GameButton(title: button.title, maxWidth: reader.size.width * buttonMultiplier, action: buttonAction)
             } else {
-                GameButton(type: button.type, action: buttonAction)
+                GameButton(type: button.type, maxWidth: reader.size.width * buttonMultiplier, action: buttonAction)
             }
         }
     }
 
-    @ViewBuilder
-    private var dismissButtonView: some View {
+    @ViewBuilder private func dismissButtonView(_ reader: GeometryProxy) -> some View {
         if let button = dismissButton {
             let buttonAction = {
                 animate(isShown: false) {
@@ -230,9 +224,9 @@ struct GameAlert: View {
                 }
             }
             if button.type == .custom {
-                GameButton(title: button.title, action: buttonAction)
+                GameButton(title: button.title, maxWidth: reader.size.width * buttonMultiplier, action: buttonAction)
             } else {
-                GameButton(type: button.type, action: buttonAction)
+                GameButton(type: button.type, maxWidth: reader.size.width * buttonMultiplier, action: buttonAction)
             }
         }
     }
@@ -288,7 +282,7 @@ struct GameAlert_Previews: PreviewProvider {
         let primaryButton   = GameButton(title: "Ok")
         let secondaryButton = GameButton(title: "Cancel")
 
-        let dismissButton2   = GameButton(type: .ok)
+        let dismissButton2   = GameButton(type: .dismiss)
         let primaryButton2   = GameButton(type: .delete)
         let secondaryButton2 = GameButton(type: .secondaryOk)
 
@@ -305,7 +299,7 @@ struct GameAlert_Previews: PreviewProvider {
 
         return VStack {
             if showType {
-                GameAlert(title: title, message: message, dismissButton: secondaryButton2, primaryButton: nil,            secondaryButton: nil)
+                GameAlert(title: title, message: message, dismissButton: dismissButton2, primaryButton: nil,            secondaryButton: nil)
                 GameAlert(title: title, message: message2, dismissButton: nil,           primaryButton: secondaryButton2, secondaryButton: primaryButton2)
             } else {
                 GameAlert(title: title, message: message, dismissButton: nil,           primaryButton: nil,           secondaryButton: nil)

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/GameButton.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/GameButton.swift
@@ -72,23 +72,26 @@ struct GameButton: View {
     let title: String
     let textColor: UIColor
     let bgColor: UIColor
+    let maxWidth: CGFloat
     var action: (() -> Void)? = nil
     private let cornerRadius: CGFloat = 25
 
-    init(title: String, textColor: UIColor = .white, type: GameButtonType = .custom, action: (() -> Void)? = nil) {
+    init(title: String, textColor: UIColor = .white, type: GameButtonType = .custom, maxWidth: CGFloat = .infinity, action: (() -> Void)? = nil) {
         self.title = title
         self.textColor = textColor
         self.bgColor = .systemBackground
         self.action = action
         self.type = type
+        self.maxWidth = maxWidth
     }
 
-    init(type: GameButtonType, action: (() -> Void)? = nil) {
+    init(type: GameButtonType, maxWidth: CGFloat = .infinity, action: (() -> Void)? = nil) {
         self.type = type
         self.title = type.title
         self.textColor = type.textColor
         self.bgColor = type.bgColor
         self.action = action
+        self.maxWidth = maxWidth
     }
 
     // MARK: - View
@@ -100,8 +103,8 @@ struct GameButton: View {
             Text(title)
                 .font(mediumTextFont)
                 .foregroundColor(Color(uiColor: textColor))
-                .frame(maxWidth: .infinity, maxHeight: 45)
-                .padding(.horizontal, 20)
+                .frame(maxWidth: maxWidth)
+                .padding(.horizontal, 25)
         }
         .background(
             type.background


### PR DESCRIPTION
    - Add a way to specify GameButton’s maxWidth
        - Solution broke GameAlert’s look and puts the button too low
        - Fixed AccountView’s back and edit button to be smaller
    - Fix UpdatePassword button’s width
    - Put UpdatePasswordView’s back button at the bottom similar to AccountView