### PR TITLE
Commit 55: Maybe also handle alert with textField (7/17)

### DIFF
--- a/iOS/FuFight/FuFight/Account/AccountViewModel.swift
+++ b/iOS/FuFight/FuFight/Account/AccountViewModel.swift
@@ -66,8 +66,10 @@ final class AccountViewModel: BaseAccountViewModel {
         Task {
             let currentUserId = account.id ?? Account.current?.userId ?? account.userId
             do {
-                updateLoadingMessage(to: Str.deletingStoredPhoto)
-                try await AccountNetworkManager.deleteStoredPhoto(currentUserId)
+                if Account.current?.photoUrl != nil {
+                    updateLoadingMessage(to: Str.deletingStoredPhoto)
+                    try await AccountNetworkManager.deleteStoredPhoto(currentUserId)
+                }
                 updateLoadingMessage(to: Str.deletingData)
                 try await AccountNetworkManager.deleteData(currentUserId)
                 try await AccountNetworkManager.deleteAuthData(userId: currentUserId)

--- a/iOS/FuFight/FuFight/App/ContentView.swift
+++ b/iOS/FuFight/FuFight/App/ContentView.swift
@@ -63,6 +63,18 @@ struct ContentView: View {
     @Namespace var namespace
     @Environment(\.scenePhase) var scenePhase
 
+    init() {
+        UINavigationBar.appearance().largeTitleTextAttributes = [
+            .foregroundColor: UIColor.white,
+            .font : UIFont(name: CustomFontWeight.black.rawValue, size: defaultFontSize * 2)!
+        ]
+        UINavigationBar.appearance().titleTextAttributes = [
+            .foregroundColor: UIColor.white,
+            .font : UIFont(name: CustomFontWeight.black.rawValue, size: defaultFontSize * 1.2)!
+        ]
+        UINavigationBar.appearance().setBackgroundImage(UIImage(), for: UIBarMetrics.default) //make the nav bar's background clear
+    }
+
     //MARK: - Views
     var body: some View {
         GeometryReader { reader in

--- a/iOS/FuFight/FuFight/Authentication/AuthenticationViewModel.swift
+++ b/iOS/FuFight/FuFight/Authentication/AuthenticationViewModel.swift
@@ -255,9 +255,11 @@ private extension AuthenticationViewModel {
                     transitionToHomeView()
                 } else {
                     ///Finish onboarding
-                    updateError(nil)
-                    updateStep(to: .onboard)
-                    topFieldIsActive = true
+                    DispatchQueue.main.async {
+                        self.updateError(nil)
+                        self.updateStep(to: .onboard)
+                        self.topFieldIsActive = true
+                    }
                 }
             } catch {
                 updateError(MainError(type: .logIn, message: error.localizedDescription))

--- a/iOS/FuFight/FuFight/Game/GameView/GameView.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/GameView.swift
@@ -39,7 +39,7 @@ struct GameView: View {
                isPresented: $vm.isAlertPresented)
         .alert(title: vm.player.isDead ? "You lost" : "You won!",
                primaryButton: AppButton(title: "Rematch", action: vm.rematch),
-               secondaryButton: AppButton(title: "Go home", action: vm.exitGame),
+               secondaryButton: AppButton(title: "Go home", type: AppButtonType.delete, action: vm.exitGame),
                isPresented: .constant(vm.player.isDead || vm.enemy.isDead))
         .alert(title: "You won!",
                message: "Congrats! Enemy rage quitted",
@@ -47,7 +47,7 @@ struct GameView: View {
                isPresented: $vm.enemyExited)
         .alert(title: "Game is paused",
                primaryButton: AppButton(title: "Resume", action: {}),
-               secondaryButton: AppButton(title: "Exit", action: vm.exitGame),
+               secondaryButton: AppButton(title: "Exit", type: AppButtonType.delete, action: vm.exitGame),
                isPresented: $vm.isGamePaused)
         .overlay {
             timerView

--- a/iOS/FuFight/FuFight/Home/HomeView.swift
+++ b/iOS/FuFight/FuFight/Home/HomeView.swift
@@ -148,7 +148,7 @@ struct HomeView: View {
     }
 
     @ViewBuilder private func offlinePlayButton(_ reader: GeometryProxy) -> some View {
-        AppButton(title: "Offline", type: .greenCustom, textType: .buttonLarge, minWidth: reader.size.width * buttonMinWidthMultiplier, maxWidth: reader.size.width * buttonMaxWidthMultiplier) {
+        AppButton(title: "Offline", type: .secondaryCancel, textType: .buttonLarge, minWidth: reader.size.width * buttonMinWidthMultiplier, maxWidth: reader.size.width * buttonMaxWidthMultiplier) {
             vm.transitionToOffline.send(vm)
         }
     }

--- a/iOS/FuFight/Helpers/Constants/ConstantTexts.swift
+++ b/iOS/FuFight/Helpers/Constants/ConstantTexts.swift
@@ -36,7 +36,7 @@ struct Str {
     static let enterPhoneSixDigitCode = "Enter 6 digit code"
     static let rememberMe = "Remember me"
     static let forgotPasswordTitleQuestion = "Forgot Password?"
-    static let putEmailOrUsernameToResetPassword = "Put your email or username to reset your password"
+    static let putEmailOrUsernameToResetPassword = "Enter email or username to reset"
     static let changePasswordTitle = "Change Password"
     static let updatePasswordTitle = "Update Password"
     static let createAccountTitle = "Create Account"
@@ -58,7 +58,7 @@ struct Str {
     static let dontHaveAnAccount = "Don't have an account? Sign up."
     static let alreadyHaveAnAccount = "Already have an account? Log in."
     static let enterYourEmail = "Enter your email"
-    static let recentReauthenticationIsRequiredToMakeChanges = "Recent reauthentication is required to make account changes"
+    static let recentReauthenticationIsRequiredToMakeChanges = "Log in again to make changes"
     static let sendingEmail = "Sending an email"
 
     //MARK: - Logs

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -112,12 +112,14 @@ let yellowRingImage: some View = Image("yellowRing").containerImageModifier()
 
 //System Images
 let defaultProfilePhoto: UIImage = UIImage(systemName: "person.crop.circle")!
-let checkedImage: UIImage = UIImage(systemName: "checkmark.square.fill")!
-let uncheckedImage: UIImage = UIImage(systemName: "square")!
+let checkedImage: some View = Image(systemName: "checkmark.square.fill")
+    .foregroundColor(Color.white)
+let uncheckedImage: some View = Image(systemName: "square")
+    .foregroundColor(Color.white)
 let securedImage: some View = Image(systemName: "eye")
-    .foregroundColor(.label)
+    .foregroundColor(Color.white)
 let nonSecuredImage: some View = Image(systemName: "eye.slash")
-    .foregroundColor(.label)
+    .foregroundColor(Color.white)
 let invalidImage: some View = Image(systemName: "xmark.circle.fill")
     .foregroundColor(Color.systemRed)
 let validImage: some View = Image(systemName: "checkmark.circle.fill")

--- a/iOS/FuFight/Helpers/CustomViews/AppButton.swift
+++ b/iOS/FuFight/Helpers/CustomViews/AppButton.swift
@@ -37,7 +37,7 @@ enum AppButtonType {
     @ViewBuilder var background: some View {
         switch self {
         case .cancel:
-            yellowButtonImage
+            redButtonImage
         case .secondaryCancel:
             blueButtonImage
         case .ok:
@@ -77,6 +77,15 @@ enum AppButtonType {
 
     var textColor: UIColor {
         .white
+    }
+
+    var isCustom: Bool {
+        switch self {
+        case .cancel, .secondaryCancel, .ok, .secondaryOk, .delete, .dismiss:
+            false
+        case .custom, .secondaryCustom, .tertiaryCustom, .greenCustom:
+            true
+        }
     }
 }
 

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/GameAlert.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/GameAlert.swift
@@ -19,9 +19,9 @@ struct GameAlert: View {
     let primaryButton: AppButton?
     let secondaryButton: AppButton?
     ///Show a TextField if this is not nil
-//    let fieldType: FieldType?
-//    @Binding var text: String
-//    @State var isFieldSecure: Bool = false
+    let fieldType: FieldType?
+    @Binding var text: String
+    @State var isFieldSecure: Bool = false
 
     // MARK: Private
     @State private var opacity: CGFloat           = 0
@@ -44,19 +44,19 @@ struct GameAlert: View {
         self.dismissButton = dismissButton
         self.primaryButton = primaryButton
         self.secondaryButton = secondaryButton
-//        fieldType = nil
-//        _text = .constant("")
+        fieldType = nil
+        _text = .constant("")
     }
 
     ///Initializer for alerts with a TextField
     init(withText text: Binding<String>, fieldType: FieldType, title: String, primaryButton: AppButton?, secondaryButton: AppButton?) {
-//        self.fieldType = fieldType
+        self.fieldType = fieldType
         self.title = title
         self.primaryButton = primaryButton
         self.secondaryButton = secondaryButton
-//        _text = text
         self.message = ""
         self.dismissButton = nil
+        _text = text
     }
 
     // MARK: - View
@@ -74,11 +74,11 @@ struct GameAlert: View {
                 animate(isShown: true)
             }
         }
-//        .onAppear {
-//            if let fieldType {
-//                isFieldSecure = fieldType.isSensitive
-//            }
-//        }
+        .onAppear {
+            if let fieldType {
+                isFieldSecure = fieldType.isSensitive
+            }
+        }
     }
 
     // MARK: Private
@@ -128,13 +128,12 @@ struct GameAlert: View {
     }
 
     @ViewBuilder private var messageView: some View {
-//        if let fieldType {
-//            UnderlinedTextField(type: .constant(fieldType), text: $text, isSecure: $isFieldSecure, showTitle: false)
-//                .onSubmit {
-//                    primaryButtonAction()
-//                }
-//        } else
-        if !message.isEmpty {
+        if let fieldType {
+            UnderlinedTextField(type: .constant(fieldType), text: $text, isSecure: $isFieldSecure, showTitle: false)
+                .onSubmit {
+                    primaryButtonAction()
+                }
+        } else if !message.isEmpty {
             if isManyText {
                 ScrollView(.vertical, showsIndicators: false) {
                     messageLabel
@@ -181,8 +180,9 @@ struct GameAlert: View {
 
     @ViewBuilder private func primaryButtonView(_ reader: GeometryProxy) -> some View {
         if let primaryButton {
-            if primaryButton.type == .custom {
-                AppButton(title: primaryButton.title, maxWidth: reader.size.width * buttonMultiplier, action: primaryButtonAction)
+            if primaryButton.type.isCustom {
+                //if type is a custom type, then show the title
+                AppButton(title: primaryButton.title, type: primaryButton.type, maxWidth: reader.size.width * buttonMultiplier, action: primaryButtonAction)
             } else {
                 AppButton(type: primaryButton.type, maxWidth: reader.size.width * buttonMultiplier, action: primaryButtonAction)
             }
@@ -200,7 +200,7 @@ struct GameAlert: View {
                     button.action?()
                 }
             }
-            if button.type == .custom {
+            if button.type.isCustom {
                 AppButton(title: button.title, maxWidth: reader.size.width * buttonMultiplier, action: buttonAction)
             } else {
                 AppButton(type: button.type, maxWidth: reader.size.width * buttonMultiplier, action: buttonAction)
@@ -219,7 +219,7 @@ struct GameAlert: View {
                     button.action?()
                 }
             }
-            if button.type == .custom {
+            if button.type.isCustom {
                 AppButton(title: button.title, maxWidth: reader.size.width * buttonMultiplier, action: buttonAction)
             } else {
                 AppButton(type: button.type, maxWidth: reader.size.width * buttonMultiplier, action: buttonAction)

--- a/iOS/FuFight/Helpers/CustomViews/UnderlinedTextField.swift
+++ b/iOS/FuFight/Helpers/CustomViews/UnderlinedTextField.swift
@@ -157,6 +157,10 @@ struct UnderlinedTextField: View {
 
     @FocusState private var isFocused: Bool
 
+    private var currentColor: Color {
+        isDisabled ? Color.lightText : Color.white
+    }
+
     init(type: Binding<FieldType>, text: Binding<String>, isSecure: Binding<Bool> = .constant(false), hasError: Binding<Bool> = .constant(false), isActive: Binding<Bool> = .constant(false), isDisabled: Binding<Bool> = .constant(false), showTitle: Bool = true, _ trailingButtonAction: (() -> Void)? = nil) {
         self._type = type
         self._text = text
@@ -178,10 +182,12 @@ struct UnderlinedTextField: View {
                 Group {
                     if isSecure {
                         SecureField(type.placeholder, text: $text)
-                            .foregroundStyle(isDisabled ? .secondary : .primary)
+                            .foregroundStyle(currentColor)
+                            .placeholder(type.placeholder, when: text.isEmpty)
                     } else {
                         TextField(type.placeholder, text: $text)
-                            .foregroundStyle(isDisabled ? .secondary : .primary)
+                            .foregroundStyle(currentColor)
+                            .placeholder(type.placeholder, when: text.isEmpty)
                     }
                 }
                 .textFieldStyle(PlainTextFieldStyle())
@@ -191,7 +197,7 @@ struct UnderlinedTextField: View {
                 .textContentType(type.contentType)
                 .submitLabel(type.submitLabel)
                 .font(Font.customFont(TextType.textLarge.fontWeight, TextType.textMedium.fontSize))
-                
+
                 accessories
             }
         }
@@ -210,7 +216,7 @@ struct UnderlinedTextField: View {
 
             Rectangle()
                 .frame(height: 1.5)
-                .foregroundStyle(hasError ? destructiveColor : (isDisabled ? disabledColor : primaryColor))
+                .foregroundStyle(hasError ? destructiveColor : currentColor)
         }
     }
 

--- a/iOS/FuFight/Helpers/Extensions/View+Extensions.swift
+++ b/iOS/FuFight/Helpers/Extensions/View+Extensions.swift
@@ -42,3 +42,25 @@ extension View {
         return modifier(MainAlertModifier(withText: text, fieldType: fieldType, title: title, primaryButton: primaryButton, secondaryButton: secondaryButton, isPresented: isPresented))
     }
 }
+
+extension View {
+    func placeholder(
+        _ text: String,
+        when shouldShow: Bool,
+        alignment: Alignment = .leading) -> some View {
+            placeholder(when: shouldShow, alignment: alignment) {
+                Text(text)
+                    .foregroundColor(Color.lightText)
+            }
+        }
+
+    private func placeholder<Content: View>(
+        when shouldShow: Bool,
+        alignment: Alignment = .leading,
+        @ViewBuilder placeholder: () -> Content) -> some View {
+            ZStack(alignment: alignment) {
+                placeholder().opacity(shouldShow ? 1 : 0)
+                self
+            }
+        }
+}


### PR DESCRIPTION
    - Updated GameAlert to support textfields
    - Updated UnderlinedTextfield and its accessories white
        - Updated to also have a lighter placeholder
    - Reduce the text count of some of the alerts
    - Make sure AuthView works and looks good
        - Updated remember me icon to be white instead
        - Fixed Finish account creation’s button as well
    - Make sure AccountView works and looks good
        - Made sure text fields, icons, texts, and buttons looks good
    - Fixed a bug where deleting a user with no photo prevents account deletion
    - Update alert’s cancel button to be red
    - Update AuthView’s nav title to be white and use custom font
        - Updated nav’s small title to be white and use custom font
        - Updated nav’s background color when small to clear from white