### PR TITLE
Commit 59: Show popup when NavBar’s imageView is tapped (7/18-7/19)

### DIFF
--- a/iOS/FuFight/FuFight/App/ContentView.swift
+++ b/iOS/FuFight/FuFight/App/ContentView.swift
@@ -56,6 +56,7 @@ struct ContentView: View {
     @StateObject var account: Account = Account.current ?? Account()
     @State var showTab: Bool = true
     @State var showNav: Bool = true
+    @State var showPlayerAlert: Bool = false
     @State var tab: Tab = .home
     private let tabs: [Tab] = Tab.allCases
     var subscriptions = Set<AnyCancellable>()
@@ -112,6 +113,15 @@ struct ContentView: View {
                         }
                     }
                 }
+                .overlay {
+                    if showPlayerAlert {
+                        PopupView(isShowing: $showPlayerAlert,
+                                  content: PlayerDetailView(isShowing: $showPlayerAlert)
+                            .frame(width: reader.size.width * 0.9)
+                            .frame(maxHeight: .infinity)
+                        )
+                    }
+                }
                 .onAppear {
                     UserDefaults.topSafeAreaInset = reader.safeAreaInsets.top
                     UserDefaults.bottomSafeAreaInset = reader.safeAreaInsets.bottom
@@ -132,6 +142,9 @@ struct ContentView: View {
         if showNav {
             NavBar {
                 //TODO: Show popup PlayerDetailView
+                withAnimation {
+                    showPlayerAlert = true
+                }
             }
         }
     }

--- a/iOS/FuFight/FuFight/App/Navigation/PlayerDetailView.swift
+++ b/iOS/FuFight/FuFight/App/Navigation/PlayerDetailView.swift
@@ -1,0 +1,92 @@
+//
+//  PlayerDetailView.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 7/19/24.
+//
+
+import SwiftUI
+
+struct PlayerDetailView: View {
+    @Binding var isShowing: Bool
+
+    private let alertWidth: CGFloat = 360
+    private let verticalPadding: CGFloat = 4
+    private let horizontalPadding: CGFloat = 12
+
+    var body: some View {
+        GeometryReader { reader in
+            alertView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background {
+                    Color.clear
+                }
+        }
+    }
+
+    @ViewBuilder func alertView() -> some View {
+        VStack(spacing: 0) {
+            alertTitleBackgroundImage
+                .overlay {
+                    titleView
+                }
+
+            alertBodyBackgroundImage
+                .frame(maxWidth: .infinity)
+                .overlay {
+                    ScrollView(.vertical, showsIndicators: false) {
+                        VStack(spacing: 4) {
+                            AppText("Username: \(Room.current?.player.username ?? "")", type: .textMedium)
+
+                            Spacer()
+                                .frame(height: 20)
+
+                            AppText("Experience: TODO/TODO", type: .textMedium)
+
+                            AppText("Ratings: TODO", type: .textMedium)
+
+                            AppText("Game Stats: TODO", type: .textMedium)
+
+                            AppText("Game History: TODO", type: .textMedium)
+                        }
+                        .padding(.top, verticalPadding * 2.5)
+                        .padding(.bottom, 50)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .overlay(alignment: .bottom) {
+                        okayButton
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder private var titleView: some View {
+        AppText("Player's Detail", type: .navMedium)
+            .multilineTextAlignment(.center)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+    }
+
+    @ViewBuilder private var okayButton: some View {
+        AppButton(title: "Okay", color: .main, maxWidth: navBarButtonMaxWidth * 1.5) {
+            shouldShow(false)
+        }
+        .padding(.bottom)
+    }
+}
+
+private extension PlayerDetailView {
+    func shouldShow(_ show: Bool) {
+        withAnimation {
+            isShowing = show
+        }
+    }
+}
+
+#Preview {
+    return VStack(spacing: 20) {
+        PlayerDetailView(isShowing: .constant(true))
+    }
+}

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -88,6 +88,7 @@ let navBarContainerImage: some View = Image("navBarContainer").containerImageMod
 let alertBodyBackgroundImage: some View = Image("alertBodyBackground").containerImageModifier()
 let alertTitleBackgroundImage_Shadowed: some View = Image("alertTitleBackground-shadowed").containerImageModifier()
 let alertTitleBackgroundImage: some View = Image("alertTitleBackground").containerImageModifier()
+let dimViewBackground: some View = Color.gray.opacity(0.55)
 
 //Buttons Folder
 let backButtonImage: some View = Image("backButton").buttonImageModifier()

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/GameAlert.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/GameAlert.swift
@@ -228,8 +228,7 @@ struct GameAlert: View {
     }
 
     private var dimView: some View {
-        Color.systemGray
-            .opacity(0.55)
+        dimViewBackground
             .opacity(backgroundOpacity)
             .onTapGesture {
                 animate(isShown: false) {

--- a/iOS/FuFight/Helpers/CustomViews/MainAlert/MainAlert.swift
+++ b/iOS/FuFight/Helpers/CustomViews/MainAlert/MainAlert.swift
@@ -190,8 +190,7 @@ struct MainAlert: View {
     }
 
     private var dimView: some View {
-        Color.systemGray
-            .opacity(0.55)
+        dimViewBackground
             .opacity(backgroundOpacity)
             .onTapGesture {
                 animate(isShown: false) {

--- a/iOS/FuFight/Helpers/CustomViews/PopupView.swift
+++ b/iOS/FuFight/Helpers/CustomViews/PopupView.swift
@@ -1,0 +1,38 @@
+//
+//  PopupView.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 7/18/24.
+//
+
+import SwiftUI
+
+struct PopupView<Content: View>: View {
+    @Binding var isShowing: Bool
+    let content: Content
+
+    var body: some View {
+            ZStack {
+                content
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background {
+                dimViewBackground
+                    .onTapGesture {
+                        shouldShow(false)
+                    }
+            }
+    }
+
+    private func shouldShow(_ show: Bool) {
+        withAnimation {
+            isShowing = show
+        }
+    }
+}
+
+#Preview {
+    return VStack(spacing: 20) {
+        PopupView(isShowing: .constant(true), content: Color.black)
+    }
+}


### PR DESCRIPTION
    - Create and show Player’s Details as a pop up
        - Created PopupView which takes a content
            - Made PopupView have an okay button that dismisses the alert
        - Created PlayerDetailView and made it PopupView’s content
            - PlayerDetailView currently will only show the  username
            - Made the content have a scrollView
        - Show PlayerDetailView when NavBar’s imageView is tapped
    - Make sure it works from all Tabs