### PR TITLE
- Commit 60: Add remaining HomeButton and dummy popups (7/19 - 7/20)

### DIFF
--- a/iOS/FuFight/FuFight/App/ContentView.swift
+++ b/iOS/FuFight/FuFight/App/ContentView.swift
@@ -115,11 +115,9 @@ struct ContentView: View {
                 }
                 .overlay {
                     if showPlayerAlert {
-                        PopupView(isShowing: $showPlayerAlert,
-                                  content: PlayerDetailView(isShowing: $showPlayerAlert)
-                            .frame(width: reader.size.width * 0.9)
-                            .frame(maxHeight: .infinity)
-                        )
+                        PopupView(isShowing: $showPlayerAlert, title: "Player's Detail",
+                                  bodyContent: PlayerDetailView(isShowing: $showPlayerAlert))
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                 }
                 .onAppear {

--- a/iOS/FuFight/FuFight/App/Navigation/PlayerDetailView.swift
+++ b/iOS/FuFight/FuFight/App/Navigation/PlayerDetailView.swift
@@ -10,70 +10,22 @@ import SwiftUI
 struct PlayerDetailView: View {
     @Binding var isShowing: Bool
 
-    private let alertWidth: CGFloat = 360
-    private let verticalPadding: CGFloat = 4
-    private let horizontalPadding: CGFloat = 12
-
     var body: some View {
-        GeometryReader { reader in
-            alertView()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background {
-                    Color.clear
-                }
+        VStack(spacing: 4) {
+            AppText("Username: \(Room.current?.player.username ?? "")", type: .textMedium)
+
+            Spacer()
+                .frame(height: 20)
+
+            AppText("Experience: TODO/TODO", type: .textMedium)
+
+            AppText("Ratings: TODO", type: .textMedium)
+
+            AppText("Game Stats: TODO", type: .textMedium)
+
+            AppText("Game History: TODO", type: .textMedium)
         }
-    }
-
-    @ViewBuilder func alertView() -> some View {
-        VStack(spacing: 0) {
-            alertTitleBackgroundImage
-                .overlay {
-                    titleView
-                }
-
-            alertBodyBackgroundImage
-                .frame(maxWidth: .infinity)
-                .overlay {
-                    ScrollView(.vertical, showsIndicators: false) {
-                        VStack(spacing: 4) {
-                            AppText("Username: \(Room.current?.player.username ?? "")", type: .textMedium)
-
-                            Spacer()
-                                .frame(height: 20)
-
-                            AppText("Experience: TODO/TODO", type: .textMedium)
-
-                            AppText("Ratings: TODO", type: .textMedium)
-
-                            AppText("Game Stats: TODO", type: .textMedium)
-
-                            AppText("Game History: TODO", type: .textMedium)
-                        }
-                        .padding(.top, verticalPadding * 2.5)
-                        .padding(.bottom, 50)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .overlay(alignment: .bottom) {
-                        okayButton
-                    }
-                }
-        }
-    }
-
-    @ViewBuilder private var titleView: some View {
-        AppText("Player's Detail", type: .navMedium)
-            .multilineTextAlignment(.center)
-            .lineLimit(1)
-            .minimumScaleFactor(0.7)
-            .padding(.horizontal, horizontalPadding)
-            .padding(.vertical, verticalPadding)
-    }
-
-    @ViewBuilder private var okayButton: some View {
-        AppButton(title: "Okay", color: .main, maxWidth: navBarButtonMaxWidth * 1.5) {
-            shouldShow(false)
-        }
-        .padding(.bottom)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 

--- a/iOS/FuFight/FuFight/Home/HomeButtonType.swift
+++ b/iOS/FuFight/FuFight/Home/HomeButtonType.swift
@@ -32,21 +32,30 @@ struct PopoverButton<PopOverContent: View>: View {
 }
 
 enum HomeButtonType: String, CaseIterable {
-    case leading1
-    case leading2
-    case leading3
-    case accountDetail
-    case trailing2
-    case friendPicker
+    case rewards, inbox, profile, settings
+    case promotions, tasks, chests
+    case leaderboards, friendPicker
 
     var imageName: String {
         switch self {
-        case .leading1, .leading2, .leading3:
-            "coin"
-        case .accountDetail:
-            "person.fill"
-        case .trailing2:
-            "diamond"
+        case .rewards:
+            "gift.circle"
+        case .inbox:
+            "message.circle"
+        case .profile:
+            "person.circle"
+        case .settings:
+            "gearshape.circle"
+        case .promotions:
+            //TODO: Turn into promo
+            "hourglass.badge.plus"
+        case .tasks:
+            "list.clipboard.fill"
+        case .chests:
+            //TODO: Turn into chest
+            "app.gift.fill"
+        case .leaderboards:
+            "list.bullet.rectangle.portrait.fill"
         case .friendPicker:
             "person.2.fill"
         }
@@ -55,30 +64,31 @@ enum HomeButtonType: String, CaseIterable {
     var image: some View {
         Group {
             switch self {
-            case .leading1, .leading2, .leading3, .trailing2:
-                Image(imageName)
-                    .defaultImageModifier()
-                    .frame(width: 40, height: 50)
-            case .accountDetail:
+            case .rewards, .inbox, .profile, .settings:
                 Image(systemName: imageName)
                     .defaultImageModifier()
-                    .frame(width: 30, height: 40)
-                    .padding(.horizontal, 5)
+            case .promotions, .tasks, .chests:
+                Image(systemName: imageName)
+                    .defaultImageModifier()
+            case .leaderboards:
+                Image(systemName: imageName)
+                    .defaultImageModifier()
             case .friendPicker:
                 Image(systemName: imageName)
                     .defaultImageModifier()
-                    .frame(width: 40, height: 40)
             }
         }
-        .foregroundStyle(Color.white)
-        .padding(4)
+        .foregroundStyle(position == .topTrailing ? Color.white : Color.black)
+        .padding(position == .topTrailing ? 4 : 16)
     }
 
     var position: Position {
         switch self {
-        case .leading1, .leading2, .leading3:
+        case .rewards, .inbox, .profile, .settings:
+                .topTrailing
+        case .promotions, .tasks, .chests:
                 .leading
-        case .accountDetail, .trailing2, .friendPicker:
+        case .leaderboards, .friendPicker:
                 .trailing
         }
     }
@@ -100,6 +110,7 @@ extension HomeButtonType {
     enum Position {
         case leading
         case trailing
+        case topTrailing
 
         var edge: Edge {
             switch self {
@@ -107,6 +118,8 @@ extension HomeButtonType {
                     .leading
             case .trailing:
                     .trailing
+            case .topTrailing:
+                    .top
             }
         }
         var edgeSet: Edge.Set {
@@ -115,6 +128,8 @@ extension HomeButtonType {
                     .leading
             case .trailing:
                     .trailing
+            case .topTrailing:
+                    .top
             }
         }
     }

--- a/iOS/FuFight/FuFight/Home/HomeView.swift
+++ b/iOS/FuFight/FuFight/Home/HomeView.swift
@@ -17,8 +17,10 @@ struct HomeView: View {
                 //            fighterView
 
                 VStack(spacing: 0) {
+                    homeButtonsView(position: .topTrailing, reader: reader)
+
                     HStack(alignment: .top) {
-                        sideButtonsView(position: .leading, reader: reader)
+                        homeButtonsView(position: .leading, reader: reader)
 
                         Spacer()
 
@@ -30,8 +32,9 @@ struct HomeView: View {
 
                         Spacer()
 
-                        sideButtonsView(position: .trailing, reader: reader)
+                        homeButtonsView(position: .trailing, reader: reader)
                     }
+                    .padding(.top, 25)
 
                     Spacer()
 
@@ -45,6 +48,11 @@ struct HomeView: View {
         .padding(.bottom, homeTabBarHeight)
         .overlay {
             LoadingView(message: vm.loadingMessage)
+        }
+        .overlay {
+            GeometryReader { reader in
+                homeButtonAlerts(reader)
+            }
         }
         .background {
             GeometryReader { reader in
@@ -72,6 +80,64 @@ struct HomeView: View {
         .allowsHitTesting(vm.loadingMessage == nil)
     }
 
+    @ViewBuilder func homeButtonAlerts(_ reader: GeometryProxy) -> some View {
+        if vm.showRewards {
+            PopupView(isShowing: $vm.showRewards,
+                      title: "TODO: Rewards",
+                      bodyContent: VStack {
+
+            })
+        } else if vm.showInbox {
+            PopupView(isShowing: $vm.showInbox,
+                      title: "TODO: Inbox",
+                      bodyContent: VStack {
+                AppText("TODO:::", type: .textMedium)
+
+                AppText("TODO:::", type: .textMedium)
+            })
+        } else if vm.showSettings {
+            PopupView(isShowing: $vm.showSettings,
+                      title: "TODO: Settings",
+                      bodyContent: VStack {
+                AppText("TODO:::", type: .textMedium)
+
+                AppText("TODO:::", type: .textMedium)
+            })
+        } else if vm.showPromotions {
+            PopupView(isShowing: $vm.showPromotions,
+                      title: "TODO: Promotions",
+                      bodyContent: VStack {
+                AppText("TODO:::", type: .textMedium)
+
+                AppText("TODO:::", type: .textMedium)
+            })
+        } else if vm.showTasks {
+            PopupView(isShowing: $vm.showTasks,
+                      title: "TODO: Tasks",
+                      bodyContent: VStack {
+                AppText("TODO:::", type: .textMedium)
+
+                AppText("TODO:::", type: .textMedium)
+            })
+        } else if vm.showChests {
+            PopupView(isShowing: $vm.showChests,
+                      title: "TODO: Chests",
+                      bodyContent: VStack {
+                AppText("TODO:::", type: .textMedium)
+
+                AppText("TODO:::", type: .textMedium)
+            })
+        } else if vm.showLeaderboards {
+            PopupView(isShowing: $vm.showLeaderboards,
+                      title: "TODO: Leaderboards",
+                      bodyContent: VStack {
+                AppText("TODO:::", type: .textMedium)
+
+                AppText("TODO:::", type: .textMedium)
+            })
+        }
+    }
+
     @ViewBuilder var fighterView: some View {
         if let player = Room.current?.player {
             DaePreview(scene: createFighterScene(fighterType: player.fighterType, animation: .idleStand))
@@ -79,22 +145,38 @@ struct HomeView: View {
         }
     }
 
-    @ViewBuilder func sideButtonsView(position: HomeButtonType.Position, reader: GeometryProxy) -> some View {
+    @ViewBuilder func homeButtonsView(position: HomeButtonType.Position, reader: GeometryProxy) -> some View {
         if !vm.isOffline {
-            VStack {
-                ForEach(vm.availableButtonTypes.compactMap { $0.position == position ? $0 : nil }, id: \.id) { buttonType in
-                    switch buttonType {
-                        case .leading1, .leading2, .leading3, .accountDetail, .trailing2:
+            if position == .topTrailing {
+                HStack {
+                    Spacer()
+
+                    ForEach(vm.availableButtonTypes.compactMap({ $0.position == .topTrailing ? $0 : nil }), id: \.id) { buttonType in
                         Button {
-                            switch buttonType {
-                            case .leading1, .leading2, .leading3, .trailing2, .friendPicker:
-                                break
-                            case .accountDetail:
-                                vm.transitionToAccount.send(vm)
-                            }
+                            vm.homeButtonTapped(buttonType)
                         } label: {
                             buttonType.image
                         }
+                    }
+                }
+                .frame(height: 35)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.trailing, smallerHorizontalPadding - 4)
+                .transition(.move(edge: .trailing))
+            } else {
+                //Side buttons
+                VStack(alignment: .center, spacing: 16) {
+                    ForEach(vm.availableButtonTypes.compactMap { $0.position == position ? $0 : nil }, id: \.id) { buttonType in
+                        switch buttonType {
+                        case .promotions, .tasks, .chests, .leaderboards, .rewards, .inbox, .profile, .settings:
+                            Button {
+                                vm.homeButtonTapped(buttonType)
+                            } label: {
+                                buttonType.image
+                            }
+                            .background {
+                                roundedButtonBackgroundImage
+                            }
                         case .friendPicker:
                             PopoverButton(type: buttonType, showPopover: $vm.showFriendPicker, popOverContent: {
                                 friendPickerView(reader)
@@ -102,13 +184,18 @@ struct HomeView: View {
                             .overlay(alignment: .bottomLeading) {
                                 onlineFriendsCountLabel
                             }
+                            .background {
+                                roundedButtonBackgroundImage
+                            }
                         }
+                    }
                 }
+                .frame(width: 60)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(position.edgeSet, smallerHorizontalPadding - 4)
+                .transition(.move(edge: position.edge))
+
             }
-            .padding(position.edgeSet, smallerHorizontalPadding - 4)
-            .transition(.move(edge: position.edge))
-        } else {
-            EmptyView()
         }
     }
 

--- a/iOS/FuFight/FuFight/Home/HomeViewModel.swift
+++ b/iOS/FuFight/FuFight/Home/HomeViewModel.swift
@@ -16,6 +16,13 @@ final class HomeViewModel: BaseAccountViewModel {
     @Published var selectedGameType: GameType = .casual
     @Published var isOffline: Bool = false
     @Published var showFriendPicker: Bool = false
+    @Published var showRewards: Bool = false
+    @Published var showInbox: Bool = false
+    @Published var showSettings: Bool = false
+    @Published var showPromotions: Bool = false
+    @Published var showTasks: Bool = false
+    @Published var showChests: Bool = false
+    @Published var showLeaderboards: Bool = false
 
     let gameTypes: [GameType] = GameType.allCases
     let availableButtonTypes: [HomeButtonType] = HomeButtonType.allCases
@@ -47,10 +54,22 @@ final class HomeViewModel: BaseAccountViewModel {
 
     func homeButtonTapped(_ buttonType: HomeButtonType) {
         switch buttonType {
-        case .leading1, .leading2, .leading3:
-            LOG("Tapped leading button \(buttonType.rawValue)")
-        case .accountDetail, .trailing2:
-            LOG("Tapped trailing button \(buttonType.rawValue)")
+        case .rewards:
+            showRewards.toggle()
+        case .inbox:
+            showInbox.toggle()
+        case .profile:
+            transitionToAccount.send(self)
+        case .settings:
+            showSettings.toggle()
+        case .promotions:
+            showPromotions.toggle()
+        case .tasks:
+            showTasks.toggle()
+        case .chests:
+            showChests.toggle()
+        case .leaderboards:
+            showLeaderboards.toggle()
         case .friendPicker:
             break
         }

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -89,6 +89,7 @@ let alertBodyBackgroundImage: some View = Image("alertBodyBackground").container
 let alertTitleBackgroundImage_Shadowed: some View = Image("alertTitleBackground-shadowed").containerImageModifier()
 let alertTitleBackgroundImage: some View = Image("alertTitleBackground").containerImageModifier()
 let dimViewBackground: some View = Color.gray.opacity(0.55)
+let roundedButtonBackgroundImage: some View = Image("borderedCircle").containerImageModifier()
 
 //Buttons Folder
 let backButtonImage: some View = Image("backButton").buttonImageModifier()

--- a/iOS/FuFight/Helpers/CustomViews/PopupView.swift
+++ b/iOS/FuFight/Helpers/CustomViews/PopupView.swift
@@ -7,21 +7,59 @@
 
 import SwiftUI
 
-struct PopupView<Content: View>: View {
+struct PopupView<BodyContent: View>: View {
     @Binding var isShowing: Bool
-    let content: Content
+    let title: String?
+    let bodyContent: BodyContent?
+
+    private let alertWidth: CGFloat = 360
+    private let verticalPadding: CGFloat = 4
+    private let horizontalPadding: CGFloat = 12
 
     var body: some View {
+        GeometryReader { reader in
             ZStack {
-                content
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background {
                 dimViewBackground
                     .onTapGesture {
                         shouldShow(false)
                     }
+
+                VStack(spacing: 0) {
+                    alertTitleBackgroundImage
+                        .overlay {
+                            if let title {
+                                AppText(title, type: .navMedium)
+                                    .multilineTextAlignment(.center)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.7)
+                                    .padding(.horizontal, horizontalPadding)
+                                    .padding(.vertical, verticalPadding)
+                            }
+                        }
+
+                    alertBodyBackgroundImage
+                        .overlay {
+                            ScrollView(.vertical, showsIndicators: false) {
+                                bodyContent
+                                    .padding(.top, verticalPadding * 2.5)
+                                    .padding(.bottom, 50)
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            }
+                            .overlay(alignment: .bottom) {
+                                okayButton
+                            }
+                        }
+                }
+                .frame(width: reader.size.width * 0.9)
             }
+        }
+    }
+
+    @ViewBuilder private var okayButton: some View {
+        AppButton(title: "Okay", color: .main, maxWidth: navBarButtonMaxWidth * 1.5) {
+            shouldShow(false)
+        }
+        .padding(.bottom)
     }
 
     private func shouldShow(_ show: Bool) {
@@ -32,7 +70,28 @@ struct PopupView<Content: View>: View {
 }
 
 #Preview {
+    let titleContent =  AppText("Player's Detail", type: .navMedium)
+        .multilineTextAlignment(.center)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 10)
+    let bodyContent = VStack(spacing: 4) {
+        AppText("Username: \(Room.current?.player.username ?? "")", type: .textMedium)
+
+        Spacer()
+            .frame(height: 20)
+
+        AppText("Experience: TODO/TODO", type: .textMedium)
+
+        AppText("Ratings: TODO", type: .textMedium)
+
+        AppText("Game Stats: TODO", type: .textMedium)
+
+        AppText("Game History: TODO", type: .textMedium)
+    }
+
     return VStack(spacing: 20) {
-        PopupView(isShowing: .constant(true), content: Color.black)
+        PopupView(isShowing: .constant(true), title: "Text popup", bodyContent: bodyContent)
     }
 }


### PR DESCRIPTION
    - TopTrailing buttons: Rewards, Inbox, Profile, Settings,
        - They will be a little smaller than the other home buttons
    - Leading buttons: Promo, Tasks, Chests
        - Add a rounded button background image
    - Trailing buttons: Friends, Leaderboard
        - Add a rounded button background image
    - Updated PopupView to be more generic and reusable for both HomeAlerts and NavAlert
        - Moved the background image, okay button, and scrollView to the PopUpView
        - Changed PlayerDetailView to still show properly after PopUpView changes
    - Show an incomplete PopUpView implementation when any home button is tapped