### PR TITLE
Commit 68: Add a way to keep track of purchased fighters (7/24-7/25)

### DIFF
--- a/iOS/FuFight/FuFight/Room/CharacterListView.swift
+++ b/iOS/FuFight/FuFight/Room/CharacterListView.swift
@@ -15,8 +15,16 @@ struct CharacterListView: View {
         LazyVGrid(columns: columns, spacing: characterItemSpacing) {
             ForEach(characters, id: \.self) { character in
                 CharacterObjectCell(character: character, isSelected: character.id == selectedFighterType?.id) {
-                    LOGD("CHARACTER SELECTED \(character.fighterType.name)")
-                    selectedFighterType = character.fighterType
+                    switch character.status {
+                    case .upcoming:
+                        TODO("Upcoming \(character.fighterType.name)")
+                    case .locked:
+                        TODO("Buy \(character.fighterType.name)")
+                    case .unlocked:
+                        selectedFighterType = character.fighterType
+                    case .selected:
+                        break
+                    }
                 }
             }
         }
@@ -49,21 +57,25 @@ struct CharacterObjectCell: View {
                     VStack {
                         Spacer()
 
-                        if isSelected {
-                            HStack {
-                                fighterRankLabel
+                        switch character.status {
+                        case .upcoming:
+                            EmptyView()
 
-                                Spacer()
-
-                                fighterRatingLabel
-                            }
-                        } else {
+                        case .locked:
                             HStack {
                                 coinButton
 
                                 Spacer()
 
                                 diamondButton
+                            }
+                        case .unlocked, .selected:
+                            HStack {
+                                fighterRankLabel
+
+                                Spacer()
+
+                                fighterRatingLabel
                             }
                         }
                     }
@@ -83,6 +95,22 @@ struct CharacterObjectCell: View {
                 AppText(character.fighterType.name, type: .textSmall)
                     .padding(.bottom, 4)
             }
+            .overlay {
+                switch character.status {
+                case .upcoming:
+                    Color.black.opacity(0.6)
+                        .overlay {
+                            lockOverlay(isUpcoming: true)
+                        }
+                case .locked:
+                    lockOverlay(isUpcoming: false)
+
+                case .unlocked:
+                    EmptyView()
+                case .selected:
+                    EmptyView()
+                }
+            }
             .background(Color.blackLight)
             .padding(characterItemBorderWidth)
             .border(.yellow, width: isSelected ? characterItemBorderWidth : 0)
@@ -90,6 +118,27 @@ struct CharacterObjectCell: View {
             .lineLimit(1)
         })
         .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+    }
+
+    @ViewBuilder func lockOverlay(isUpcoming: Bool) -> some View {
+        VStack {
+            HStack {
+                Spacer()
+
+                lockImage
+                    .frame(width: 30)
+                    .padding(.top, characterItemBorderWidth)
+            }
+
+            Spacer()
+
+            if isUpcoming {
+                AppText("Coming soon", type: .buttonSmall)
+
+                Spacer()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     var coinButton: some View {

--- a/iOS/FuFight/FuFight/Room/CharacterObject.swift
+++ b/iOS/FuFight/FuFight/Room/CharacterObject.swift
@@ -7,16 +7,41 @@
 
 import Foundation
 
-struct CharacterObject: Identifiable, Hashable {
+enum PurchaseStatus: Int {
+    case upcoming
+    case locked
+    case unlocked
+    case selected
+
+    var sortOrder: Int {
+        switch self {
+        case .upcoming:
+            2
+        case .locked:
+            1
+        case .unlocked:
+            0
+        case .selected:
+            0
+        }
+    }
+}
+
+struct CharacterObject: Identifiable, Hashable, Comparable {
     var fighterType: FighterType
+    var status: PurchaseStatus
 
     var id: String { fighterType.rawValue }
+
+    public func hash(into hasher: inout Hasher) {
+        return hasher.combine(id)
+    }
 
     static func == (lhs: CharacterObject, rhs: CharacterObject) -> Bool {
         return lhs.id == rhs.id
     }
 
-    public func hash(into hasher: inout Hasher) {
-        return hasher.combine(id)
+    static func < (lhs: CharacterObject, rhs: CharacterObject) -> Bool {
+        return lhs.status.sortOrder < rhs.status.sortOrder
     }
 }

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -121,6 +121,8 @@ let invalidImage: some View = Image(systemName: "xmark.circle.fill")
     .foregroundColor(Color.systemRed)
 let validImage: some View = Image(systemName: "checkmark.circle.fill")
     .foregroundColor(Color.systemGreen)
+let lockImage: some View = Image(systemName: "lock.fill")
+    .foregroundColor(Color.white)
 
 let defaultAllPunchAttacks: [Attack] = Punch.allCases.compactMap { Attack($0) }
 let defaultAllDashDefenses: [Defense] = Dash.allCases.compactMap { Defense($0) }
@@ -148,7 +150,8 @@ let fakeEnemyPlayer = Player(userId: "fakeEnemyPlayer",
 let allAnimations: [AnimationType] = otherAnimations + defaultAllPunchAttacks.compactMap{ $0.animationType } + defaultAllDashDefenses.compactMap{ $0.animationType }
 let otherAnimations: [AnimationType] = [.idleFight, .idleStand, .dodgeHeadLeft, .dodgeHeadRight, .hitHeadRightLight, .hitHeadLeftLight, .hitHeadStraightLight, .hitHeadRightMedium, .hitHeadLeftMedium, .hitHeadStraightMedium, .hitHeadRightHard, .hitHeadLeftHard, .hitHeadStraightHard, .killHeadRightLight, .killHeadLeftLight, .killHeadRightMedium, .killHeadLeftMedium, .killHeadRightHard, .killHeadLeftHard]
 
-let characters = FighterType.allCases.compactMap { CharacterObject(fighterType: $0) }
+let characters = FighterType.allCases.compactMap { CharacterObject(fighterType: $0, status: [.locked, .unlocked, .upcoming].randomElement()!) }
+    .sorted(by: { $0 < $1 })
 let fakeNews: [News] = [
     News(title: "TODO: News", type: .announcement),
     News(title: "TODO: New Character1", type: .newCharacter),


### PR DESCRIPTION
    - Add `PurchaseStatus` enum to keep track of `CharacterObject`'s state
        - upcoming, locked, unlocked, selected
        - Initially made all characters in RoomView have the default status of locked
    - Add a way to run different actions based on PurchaseStatus
    - Load RoomView’s characters with randonm PurchaseStatus
    - Sort characters based on PurchaseStatus