### PR TITLE
Commit 69: Add logic to keep track of purchased fighters (7/25 - 7/26)

### DIFF
--- a/iOS/FuFight/FuFight/Game/GameView/Model/FighterType.swift
+++ b/iOS/FuFight/FuFight/Game/GameView/Model/FighterType.swift
@@ -104,6 +104,33 @@ enum FighterType: String, CaseIterable, Identifiable {
         "\(assetsPath)\(rawValue)"
     }
 
+    var isReleased: Bool {
+        switch self {
+        case .samuel:
+            true
+        case .clara:
+            true
+        case .kim:
+            false
+        case .deeJay:
+            false
+        case .jad:
+            false
+        case .ruby:
+            false
+        case .cain:
+            false
+        case .andrew:
+            false
+        case .corey:
+            false
+        case .alexis:
+            false
+        case .neverRight:
+            false
+        }
+    }
+
     //MARK: - Public Methods
     func animationPath(_ animationType: AnimationType) -> String {
         "\(path)/\(animationType.animationPath)"

--- a/iOS/FuFight/FuFight/Room/CharacterListView.swift
+++ b/iOS/FuFight/FuFight/Room/CharacterListView.swift
@@ -9,17 +9,20 @@ import SwiftUI
 
 struct CharacterListView: View {
     @Binding var selectedFighterType: FighterType?
-    let columns = Array(repeating: GridItem(.adaptive(minimum: 160), spacing: characterItemSpacing), count: 3)
+    let fighters: [CharacterObject]
+    let buyAction: ((_ fighterType: FighterType) -> Void)?
+
+    private let columns = Array(repeating: GridItem(.adaptive(minimum: 160), spacing: characterItemSpacing), count: 3)
 
     var body: some View {
         LazyVGrid(columns: columns, spacing: characterItemSpacing) {
-            ForEach(characters, id: \.self) { character in
+            ForEach(fighters, id: \.self) { character in
                 CharacterObjectCell(character: character, isSelected: character.id == selectedFighterType?.id) {
                     switch character.status {
                     case .upcoming:
                         TODO("Upcoming \(character.fighterType.name)")
                     case .locked:
-                        TODO("Buy \(character.fighterType.name)")
+                        buyAction?(character.fighterType)
                     case .unlocked:
                         selectedFighterType = character.fighterType
                     case .selected:
@@ -186,5 +189,5 @@ struct CharacterObjectCell: View {
 }
 
 #Preview {
-    CharacterListView(selectedFighterType: .constant(.clara))
+    CharacterListView(selectedFighterType: .constant(.clara), fighters: fakeAllFighters, buyAction: nil)
 }

--- a/iOS/FuFight/FuFight/Room/CharacterObject.swift
+++ b/iOS/FuFight/FuFight/Room/CharacterObject.swift
@@ -27,10 +27,21 @@ enum PurchaseStatus: Int {
     }
 }
 
-struct CharacterObject: Identifiable, Hashable, Comparable {
+struct CharacterObject {
     var fighterType: FighterType
     var status: PurchaseStatus
 
+    init(fighterType: FighterType) {
+        self.fighterType = fighterType
+        if !fighterType.isReleased {
+            self.status = .upcoming
+        } else {
+            self.status = RoomManager.isPurchased(fighterType) ? .unlocked : .locked
+        }
+    }
+}
+
+extension CharacterObject: Identifiable, Hashable, Comparable {
     var id: String { fighterType.rawValue }
 
     public func hash(into hasher: inout Hasher) {

--- a/iOS/FuFight/FuFight/Room/Room.swift
+++ b/iOS/FuFight/FuFight/Room/Room.swift
@@ -15,6 +15,7 @@ class Room: Identifiable, Equatable, Codable {
     var currentGame: FetchedGame?
     var challengers: [FetchedPlayer] = []
     var status: Status = .online
+    var unlockedFighterIds: [String] = []
 
     ///Returns the currently signed in account's room
     static var current: Room? {
@@ -33,6 +34,7 @@ class Room: Identifiable, Equatable, Codable {
         case challengers = "challengers"
         case playerId = "playerId"
         case status = "status"
+        case unlockedFighterIds = "unlockedFighterIds"
     }
 
     func encode(to encoder: Encoder) throws {
@@ -48,6 +50,7 @@ class Room: Identifiable, Equatable, Codable {
         if let currentGame {
             try container.encode(currentGame, forKey: .currentGame)
         }
+        try container.encode(unlockedFighterIds, forKey: .unlockedFighterIds)
     }
 
     required init(from decoder: Decoder) throws {
@@ -58,6 +61,7 @@ class Room: Identifiable, Equatable, Codable {
         self.challengers = try values.decodeIfPresent(Array<FetchedPlayer>.self, forKey: .challengers) ?? []
         self.documentId = try values.decodeIfPresent(String.self, forKey: .playerId)!
         self.currentGame = try values.decodeIfPresent(FetchedGame.self, forKey: .currentGame)
+        self.unlockedFighterIds = try values.decodeIfPresent(Array<String>.self, forKey: .unlockedFighterIds) ?? []
     }
     
     //MARK: Equatable and Identifiable requirements

--- a/iOS/FuFight/FuFight/Room/RoomManager.swift
+++ b/iOS/FuFight/FuFight/Room/RoomManager.swift
@@ -111,3 +111,10 @@ class RoomManager {
         saveCurrent(room)
     }
 }
+
+//MARK: Purchases extension
+extension RoomManager {
+    static func isPurchased(_ fighterType: FighterType) -> Bool {
+        return Room.current?.unlockedFighterIds.contains(fighterType.id) ?? false
+    }
+}

--- a/iOS/FuFight/FuFight/Room/RoomView.swift
+++ b/iOS/FuFight/FuFight/Room/RoomView.swift
@@ -20,7 +20,7 @@ struct RoomView: View {
                         Spacer()
 
                         VStack {
-                            CharacterListView(selectedFighterType: $vm.selectedFighterType)
+                            CharacterListView(selectedFighterType: $vm.selectedFighterType, fighters: vm.fighters, buyAction: vm.buyFighter(_:))
                                 .padding(.horizontal, smallerHorizontalPadding)
                         }
                         .padding(.bottom, homeBottomViewHeight)
@@ -39,6 +39,11 @@ struct RoomView: View {
                 bottomButtonsView(reader)
             }
         }
+        .overlay {
+            GeometryReader { reader in
+                alertViews(reader)
+            }
+        }
         .navigationBarHidden(true)
         .frame(maxWidth: .infinity)
         .background {
@@ -51,6 +56,9 @@ struct RoomView: View {
             vm.onDisappear()
         }
         .allowsHitTesting(vm.loadingMessage == nil)
+        .task {
+            vm.loadFighters()
+        }
     }
 
     @ViewBuilder func bottomButtonsView(_ reader: GeometryProxy) -> some View {
@@ -62,6 +70,16 @@ struct RoomView: View {
                 .frame(height: charactersBottomButtonsHeight)
                 .padding(.horizontal, smallerHorizontalPadding)
                 .padding(.bottom, homeTabBarHeightPadded + 5)
+        }
+    }
+
+    @ViewBuilder func alertViews(_ reader: GeometryProxy) -> some View {
+        if vm.showBuyFighterAlert,
+           let fighterToBuy = vm.fighterToBuy {
+            PopupView(isShowing: $vm.showBuyFighterAlert,
+                      title: "Unlock fighter?",
+                      showOkayButton: false,
+                      bodyContent: UnlockFighterView(fighterType: fighterToBuy))
         }
     }
 }

--- a/iOS/FuFight/FuFight/Room/RoomViewModel.swift
+++ b/iOS/FuFight/FuFight/Room/RoomViewModel.swift
@@ -19,6 +19,9 @@ final class RoomViewModel: BaseAccountViewModel {
     }
     @Published var selectedBottomButtonIndex: Int = 0
     @Published var showBottomButtonDropDown: Bool = false
+    @Published var fighters: [CharacterObject] = []
+    @Published var showBuyFighterAlert: Bool = false
+    @Published var fighterToBuy: FighterType? = nil
 
     let playerType: PlayerType = .user
     let roomBottomButtons: [RoomButtonType] = RoomButtonType.allCases
@@ -29,7 +32,16 @@ final class RoomViewModel: BaseAccountViewModel {
     }
 
     //MARK: - Public Methods
+    func loadFighters() {
+        fighters = FighterType.allCases.compactMap { CharacterObject(fighterType: $0) }
+            .sorted(by: { $0 < $1 })
+    }
 
+    func buyFighter(_ fighterType: FighterType) {
+        TODO("Buying \(fighterType.name)")
+        fighterToBuy = fighterType
+        showBuyFighterAlert.toggle()
+    }
 }
 
 private extension RoomViewModel {

--- a/iOS/FuFight/FuFight/Room/UnlockFighterView.swift
+++ b/iOS/FuFight/FuFight/Room/UnlockFighterView.swift
@@ -1,0 +1,46 @@
+//
+//  UnlockFighterView.swift
+//  FuFight
+//
+//  Created by Samuel Folledo on 7/26/24.
+//
+
+import SwiftUI
+
+struct UnlockFighterView: View {
+    var fighterType: FighterType
+
+    var body: some View {
+        GeometryReader { reader in
+            VStack(spacing: 20) {
+                HStack(alignment: .top) {
+                    Image(fighterType.headShotImageName)
+                        .defaultImageModifier()
+                        .clipShape(RoundedRectangle(cornerRadius: rectangleCornerRadius))
+
+                    VStack(alignment: .leading) {
+                        AppText("\(fighterType.name)", type: .alertMedium)
+
+                        AppText("Fighter is one of the best characters ever", type: .alertSmall)
+                    }
+
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, smallerHorizontalPadding)
+
+                HStack {
+                    AppButton(title: "Coins",
+                              imageName: "coin",
+                              color: .main,
+                              maxWidth: reader.size.width * 0.3)
+
+                    AppButton(title: "Diamonds", 
+                              imageName: "diamond",
+                              color: .main2,
+                              maxWidth: reader.size.width * 0.3)
+                }
+            }
+        }
+    }
+}

--- a/iOS/FuFight/Helpers/Constants/ConstantKeys.swift
+++ b/iOS/FuFight/Helpers/Constants/ConstantKeys.swift
@@ -40,6 +40,7 @@ public let kCHALLENGERS: String = "challengers"
 public let kPLAYERID: String = "playerId"
 public let kPLAYERINITIALLYHASSPEEDBOOST: String = "playerInitiallyHasSpeedBoost"
 public let kSTATUS: String = "status"
+public let kUNLOCKEDFIGHTERIDS: String = "unlockedFighterIds"
 
 //Selected Move Keys
 public let kSELECTEDMOVES: String = "selectedMoves"

--- a/iOS/FuFight/Helpers/Constants/Constants.swift
+++ b/iOS/FuFight/Helpers/Constants/Constants.swift
@@ -150,8 +150,7 @@ let fakeEnemyPlayer = Player(userId: "fakeEnemyPlayer",
 let allAnimations: [AnimationType] = otherAnimations + defaultAllPunchAttacks.compactMap{ $0.animationType } + defaultAllDashDefenses.compactMap{ $0.animationType }
 let otherAnimations: [AnimationType] = [.idleFight, .idleStand, .dodgeHeadLeft, .dodgeHeadRight, .hitHeadRightLight, .hitHeadLeftLight, .hitHeadStraightLight, .hitHeadRightMedium, .hitHeadLeftMedium, .hitHeadStraightMedium, .hitHeadRightHard, .hitHeadLeftHard, .hitHeadStraightHard, .killHeadRightLight, .killHeadLeftLight, .killHeadRightMedium, .killHeadLeftMedium, .killHeadRightHard, .killHeadLeftHard]
 
-let characters = FighterType.allCases.compactMap { CharacterObject(fighterType: $0, status: [.locked, .unlocked, .upcoming].randomElement()!) }
-    .sorted(by: { $0 < $1 })
+let fakeAllFighters = FighterType.allCases.compactMap { CharacterObject(fighterType: $0) }
 let fakeNews: [News] = [
     News(title: "TODO: News", type: .announcement),
     News(title: "TODO: New Character1", type: .newCharacter),

--- a/iOS/FuFight/Helpers/CustomViews/AppButton.swift
+++ b/iOS/FuFight/Helpers/CustomViews/AppButton.swift
@@ -94,6 +94,7 @@ enum AppButtonType {
 struct AppButton: View {
     // MARK: Public
     let title: String
+    let imageName: String?
     var type: AppButtonType
     let textType: TextType
     var color: ColorType
@@ -104,8 +105,9 @@ struct AppButton: View {
     
     private let cornerRadius: CGFloat = 25
 
-    init(title: String, color: ColorType = .main, textColor: UIColor = .white, textType: TextType = .buttonMedium, minWidth: CGFloat? = nil, maxWidth: CGFloat = .infinity, action: (() -> Void)? = nil) {
+    init(title: String, imageName: String? = nil, color: ColorType = .main, textColor: UIColor = .white, textType: TextType = .buttonMedium, minWidth: CGFloat? = nil, maxWidth: CGFloat = .infinity, action: (() -> Void)? = nil) {
         self.title = title
+        self.imageName = imageName
         self.textColor = textColor
         self.action = action
         self.type = .custom
@@ -124,6 +126,7 @@ struct AppButton: View {
         self.minWidth = minWidth
         self.maxWidth = maxWidth
         self.textType = textType
+        self.imageName = nil
     }
 
     // MARK: - View
@@ -132,9 +135,20 @@ struct AppButton: View {
         Button {
             action?()
         } label: {
-            AppText(title, type: textType)
-                .frame(minWidth: minWidth, maxWidth: maxWidth)
-                .padding(.horizontal, 25)
+            HStack(spacing: 0) {
+                if let imageName {
+                    Image(imageName)
+                        .buttonImageModifier()
+                        .padding(.vertical, -4)
+                        .padding(.leading, -4)
+                        .frame(width: navBarIconSize, height: navBarIconSize)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                AppText(title, type: textType)
+                    .frame(minWidth: minWidth, maxWidth: maxWidth)
+            }
+            .padding(.horizontal, imageName == nil ? 25 : 8)
         }
         .background(
             color.background

--- a/iOS/FuFight/Helpers/CustomViews/PopupView.swift
+++ b/iOS/FuFight/Helpers/CustomViews/PopupView.swift
@@ -10,9 +10,10 @@ import SwiftUI
 struct PopupView<BodyContent: View>: View {
     @Binding var isShowing: Bool
     let title: String?
+    var showOkayButton = true
     let bodyContent: BodyContent?
 
-    private let alertWidth: CGFloat = 360
+    private let widthMultiplier: CGFloat = 0.9
     private let verticalPadding: CGFloat = 4
     private let horizontalPadding: CGFloat = 12
 
@@ -39,18 +40,27 @@ struct PopupView<BodyContent: View>: View {
 
                     alertBodyBackgroundImage
                         .overlay {
-                            ScrollView(.vertical, showsIndicators: false) {
+                            if showOkayButton {
+                                ScrollView(.vertical, showsIndicators: false) {
+                                    bodyContent
+                                        .padding(.top, verticalPadding * 2.5)
+                                        .padding(.bottom, 50)
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                }
+                            } else {
                                 bodyContent
                                     .padding(.top, verticalPadding * 2.5)
-                                    .padding(.bottom, 50)
+                                    .padding(.bottom, 16)
                                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                             }
-                            .overlay(alignment: .bottom) {
+                        }
+                        .overlay(alignment: .bottom) {
+                            if showOkayButton {
                                 okayButton
                             }
                         }
                 }
-                .frame(width: reader.size.width * 0.9)
+                .frame(width: reader.size.width * widthMultiplier)
             }
         }
     }


### PR DESCRIPTION
    - Add a way to specify if FighterType is available to be purchase or not
        - Make Samuel and Clara locked
        - Set the rest of the FighterType to upcoming
    - Create and show UnlockFighterView
        - Put View inside a PopupView alert when tapping on locked character
        - This alert will have the fighterType to buy and 2 buttons
        - In PopupView, add a way to not show the okay button
            - when PopupView’s showOkayButton is false, do not show the body content inside a scroll view
            - Reduce body content’s bottom padding when showOkay button is false
            - Updated AppButton to be able to take an imageName
    - Have RoomManager or RoomViewModel be the source of characters and their purchase status
        - Add a way to set and get purchased fighterType in RoomManager
        - Add a way to set the purchaseStatus to upcoming when FighterType is not released yet
        - Add a way to set released characters to either locked or unlocked if it is purchased