### PR TITLE
- TODO Commit 70: Update account to have a certain amount of coins an…

### DIFF
--- a/iOS/FuFight/FuFight/App/Navigation/NavBar.swift
+++ b/iOS/FuFight/FuFight/App/Navigation/NavBar.swift
@@ -57,7 +57,7 @@ struct NavBar: View {
                     .padding(.leading, -8)
                     .frame(width: navBarIconSize, height: navBarIconSize, alignment: .center)
 
-                AppText("812999", type: .navSmall)
+                AppText("\(Account.current?.coins ?? 0)", type: .navSmall)
                     .padding(.leading, -4)
 
                 Spacer()
@@ -77,7 +77,7 @@ struct NavBar: View {
                     .padding(.leading, -16)
                     .frame(width: navBarIconSize, height: navBarIconSize)
 
-                AppText("209", type: .navSmall)
+                AppText("\(Account.current?.diamonds ?? 0)", type: .navSmall)
                     .padding(.leading, -4)
 
                 Spacer()

--- a/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
+++ b/iOS/FuFight/FuFight/App/Routers/HomeRouter.swift
@@ -116,7 +116,6 @@ class HomeRouter: ObservableObject {
         return vm
     }
 
-
     func transitionToUpdatePassword(vm: AccountViewModel) {
         navigationPath.append(.account(vm: makeAccountViewModel(account: vm.account)))
     }

--- a/iOS/FuFight/FuFight/Authentication/AuthenticationViewModel.swift
+++ b/iOS/FuFight/FuFight/Authentication/AuthenticationViewModel.swift
@@ -273,13 +273,13 @@ private extension AuthenticationViewModel {
         onlineAccount.status = .loggedIn
         Task {
             do {
-                try await AccountNetworkManager.setData(account: onlineAccount)
                 try await AccountManager.saveCurrent(onlineAccount)
 
                 if isLogIn {
                     let room = try await RoomNetworkManager.fetchRoom(onlineAccount)
                     try await RoomManager.saveCurrent(room)
                 } else {
+                    try await AccountNetworkManager.setData(account: onlineAccount)
                     TODO("Set account's Room with default values")
                     let room = Room(onlineAccount)
                     try await RoomNetworkManager.createRoom(room)

--- a/iOS/FuFight/Helpers/Base/BaseAccountViewModel.swift
+++ b/iOS/FuFight/Helpers/Base/BaseAccountViewModel.swift
@@ -39,8 +39,7 @@ private extension BaseAccountViewModel {
                     updatedUser.displayName != account.username ||
                     updatedUser.photoURL != account.photoUrl ||
                     updatedUser.email != account.email ||
-                    updatedUser.phoneNumber != account.phoneNumber ||
-                    updatedUser.metadata.creationDate != account.createdAt {
+                    updatedUser.phoneNumber != account.phoneNumber {
                     let updatedAccount = Account(updatedUser)
                     LOGD("Auth ACCOUNT changes handler for \(updatedUser.displayName ?? "")", from: BaseAccountViewModel.self)
                     self.account.update(with: updatedAccount)


### PR DESCRIPTION
…d diamonds  (7/26-7/28)

    - Show amount of coins and diamonds in the NavBar
    - TODO Fix a bug where logging in overrides database’s data
    - Show HomeView or AuthView based on AuthStep instead of previous Account.status
        - This was needed because when changing the account’s status immediately jumps to the next step without running the backend methods
        - Solved by adding a new AuthStep called authenticated
    - Fix `observeAuthChanges()` being called too much. Issue was because of createdDate property
    - Fix log out to set auth step to log in