### PR TITLE
Commit 73: RoomView fighter purchase clean ups (8/3 - 8/4)

### DIFF
--- a/iOS/FuFight/FuFight/App/ContentView.swift
+++ b/iOS/FuFight/FuFight/App/ContentView.swift
@@ -137,7 +137,7 @@ struct ContentView: View {
 
     @ViewBuilder func navBarView() -> some View {
         if showNav {
-            NavBar {
+            NavBar(account: account) {
                 //TODO: Show popup PlayerDetailView
                 withAnimation {
                     showPlayerAlert = true

--- a/iOS/FuFight/FuFight/App/Navigation/NavBar.swift
+++ b/iOS/FuFight/FuFight/App/Navigation/NavBar.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct NavBar: View {
 
+    var account: Account?
     var usernameViewTap: (() -> Void)?
 
     var body: some View {
@@ -57,7 +58,7 @@ struct NavBar: View {
                     .padding(.leading, -8)
                     .frame(width: navBarIconSize, height: navBarIconSize, alignment: .center)
 
-                AppText("\(Account.current?.coins ?? 0)", type: .navSmall)
+                AppText("\(account?.coins ?? 0)", type: .navSmall)
                     .padding(.leading, -4)
 
                 Spacer()
@@ -77,7 +78,7 @@ struct NavBar: View {
                     .padding(.leading, -16)
                     .frame(width: navBarIconSize, height: navBarIconSize)
 
-                AppText("\(Account.current?.diamonds ?? 0)", type: .navSmall)
+                AppText("\(account?.diamonds ?? 0)", type: .navSmall)
                     .padding(.leading, -4)
 
                 Spacer()

--- a/iOS/FuFight/FuFight/Room/CharacterListView.swift
+++ b/iOS/FuFight/FuFight/Room/CharacterListView.swift
@@ -27,7 +27,12 @@ struct CharacterListView: View {
                         selectedFighterType = character.fighterType
                     }
                 } buyAction: { isDiamond in
-                    buyAction?(character.fighterType, isDiamond)
+                    switch character.status {
+                    case .upcoming, .unlocked, .selected:
+                        break
+                    case .locked:
+                        buyAction?(character.fighterType, isDiamond)
+                    }
                 }
             }
         }
@@ -123,6 +128,7 @@ struct CharacterObjectCell: View {
             .lineLimit(1)
         })
         .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
+        .disabled(!character.fighterType.isReleased)
     }
 
     @ViewBuilder func lockOverlay(isUpcoming: Bool) -> some View {
@@ -148,7 +154,6 @@ struct CharacterObjectCell: View {
 
     var coinButton: some View {
         Button(action: {
-            TODO("Buy fighter \(character.fighterType.name) with COIN \(character.fighterType.name)")
             buyAction?(false)
         }, label: {
             HStack(spacing: 2) {
@@ -164,7 +169,6 @@ struct CharacterObjectCell: View {
 
     var diamondButton: some View {
         Button(action: {
-            TODO("Buy fighter \(character.fighterType.name) with DIAMOND \(character.fighterType.name)")
             buyAction?(true)
         }, label: {
             HStack(spacing: 2) {

--- a/iOS/FuFight/FuFight/Room/RoomViewModel.swift
+++ b/iOS/FuFight/FuFight/Room/RoomViewModel.swift
@@ -75,6 +75,7 @@ final class RoomViewModel: BaseAccountViewModel {
             try await RoomManager.saveCurrent(room)
             loadFighters()
             updateLoadingMessage(to: nil)
+            self.fighterToBuy = nil
             showUnlockFighterView = false
         }
     }


### PR DESCRIPTION
    - Disable fighter selection when it is not released yet
    - Update NavBar’s coins and diamonds after purchase
    - Set fighterToBuy to nil after purchasing the fighter
    - Remove buy actions and showing alert for unlocked fighters